### PR TITLE
chore: add security scanning and code quality workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "gradle"
+
+  - package-ecosystem: "gradle"
+    directory: "/eudi-wallet-oidc-android"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "gradle"
+
+  - package-ecosystem: "gradle"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "gradle"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -1,0 +1,45 @@
+name: Android Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Run Android Lint
+        run: ./gradlew lint --no-daemon --continue
+
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-lint-reports
+          path: |
+            **/build/reports/lint-results-*.html
+            **/build/reports/lint-results-*.xml
+          if-no-files-found: ignore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["java-kotlin"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: manual
+          queries: security-extended,security-and-quality
+
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,0 +1,63 @@
+name: Detekt
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 5 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  DETEKT_VERSION: "1.23.7"
+
+jobs:
+  detekt:
+    name: Detekt static analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Download detekt-cli
+        run: |
+          curl -sSLO "https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}.zip"
+          unzip -q "detekt-cli-${DETEKT_VERSION}.zip"
+          echo "${PWD}/detekt-cli-${DETEKT_VERSION}/bin" >> "$GITHUB_PATH"
+
+      - name: Run detekt
+        continue-on-error: true
+        run: |
+          detekt-cli \
+            --input . \
+            --excludes '**/build/**,**/.gradle/**,**/generated/**' \
+            --report sarif:detekt.sarif \
+            --report html:detekt.html \
+            --build-upon-default-config
+
+      - name: Upload detekt SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: detekt.sarif
+          category: detekt
+
+      - name: Upload detekt HTML report as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detekt-report
+          path: detekt.html
+          if-no-files-found: ignore

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,0 +1,28 @@
+name: Gradle Dependency Submission
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: write
+
+jobs:
+  submit-dependencies:
+    name: Submit Gradle dependency graph
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy config scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: "config"
           scan-ref: "."

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,69 @@
+name: Trivy
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  filesystem-scan:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner (filesystem)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-fs.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          ignore-unfixed: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-fs.sarif"
+          category: "trivy-fs"
+
+  config-scan:
+    name: Trivy config/IaC scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy config scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "config"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-config.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+
+      - name: Upload Trivy config results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-config.sarif"
+          category: "trivy-config"

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/VerifiableCredentialStatusList2021.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/VerifiableCredentialStatusList2021.kt
@@ -107,15 +107,15 @@ class VerifiableCredentialStatusList2021:StatusListInterface {
                         val responseString = responseBody.string()
                         Log.d("StatusList", "Success: $responseString")
                         val result = decodeStatusListJwt(responseString)
-                            if (result != null) {
-                                val verifiableCredentialsStatusList2021Model =
-                                    VerifiableCredentialsStatusList2021Model(result)
-                                val statusModel = StatusModel(
-                                    uri,
-                                    verifiableCredentialsStatusList2021Model
-                                )
-                                statusModels.add(statusModel)
-                            }
+                        if (result != null) {
+                            val verifiableCredentialsStatusList2021Model =
+                                VerifiableCredentialsStatusList2021Model(result)
+                            val statusModel = StatusModel(
+                                uri,
+                                verifiableCredentialsStatusList2021Model
+                            )
+                            statusModels.add(statusModel)
+                        }
                     } catch (e: Exception) {
                         Log.e("StatusList", "Error parsing response: ${e.message}")
                     }


### PR DESCRIPTION
## Summary
- Adds Dependabot config for weekly Gradle (root, library, app) and GitHub Actions dependency updates.
- Adds GitHub Actions workflows for CodeQL (SAST, Java/Kotlin, security-extended), Trivy (filesystem + config/IaC), Detekt (Kotlin static analysis), and Android Lint.
- All SARIF-producing scanners upload results to the GitHub Security tab under distinct categories.

## Workflows
| Workflow | Purpose | Trigger | Output |
|---|---|---|---|
| CodeQL | SAST for Java/Kotlin | push/PR to main, weekly | Security tab |
| Trivy | Filesystem + config vuln scan | push/PR to main, weekly | Security tab |
| Detekt | Kotlin static analysis | push/PR to main, weekly | Security tab + artifact |
| Android Lint | Gradle lint | push/PR to main | Artifact (HTML/XML) |
| Dependabot | Dep updates + vuln PRs | weekly | PRs |

## Follow-ups (repo admin)
After merge, enable in repo Settings → Code security:
- Dependabot alerts
- Dependabot security updates
- Secret scanning + push protection
- (CodeQL default setup is replaced by the committed workflow — keep \"Advanced\" mode.)

## Test plan
- [ ] CodeQL workflow completes and uploads SARIF
- [ ] Trivy fs + config jobs complete and upload SARIF
- [ ] Detekt completes and uploads SARIF to Security tab
- [ ] Android Lint runs \`./gradlew lint\` and uploads artifact
- [ ] Dependabot opens first round of PRs within a week