### PR TITLE
Fix #607: Replace HPKE encryptor with pure-JCA RFC 9180 implementation; remove BouncyCastle

### DIFF
--- a/eudi-wallet-oidc-android/build.gradle.kts
+++ b/eudi-wallet-oidc-android/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
 
     implementation("com.google.crypto.tink:tink-android:1.7.0")
     implementation("co.nstant.in:cbor:0.9")
-    implementation("org.bouncycastle:bcprov-jdk18on:1.79")
     implementation ("com.google.android.play:integrity:1.4.0")
     implementation ("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.+")
     implementation ("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.+")

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/dcapi/HPKEEncryptor.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/dcapi/HPKEEncryptor.kt
@@ -1,6 +1,21 @@
 package com.ewc.eudi_wallet_oidc_android.services.dcapi
 
-import org.bouncycastle.crypto.hpke.HPKE
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+import javax.crypto.Cipher
+import javax.crypto.KeyAgreement
+import javax.crypto.Mac
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 data class HPKEEncryptionResult(
     val encapsulatedKey: ByteArray,
@@ -8,12 +23,32 @@ data class HPKEEncryptionResult(
 )
 
 /**
- * HPKE encryption per ISO 18013-7 Annex C using BouncyCastle.
+ * HPKE (RFC 9180) single-shot encryption per ISO 18013-7 Annex C — pure JCA, no BouncyCastle.
  *
  * Cipher suite: DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
  * Mode: Base (0x00)
+ *
+ * Implemented against RFC 9180 §4 (DHKEM), §4.1 (LabeledExtract/Expand), §5.1 (key schedule),
+ * §5.2 (seal). Validated against the RFC 9180 Appendix A.3 test vectors (see HPKEEncryptorTest).
  */
 object HPKEEncryptor {
+
+    // RFC 9180 algorithm identifiers for this suite
+    private val KEM_ID = byteArrayOf(0x00, 0x10)   // DHKEM(P-256, HKDF-SHA256)
+    private val KDF_ID = byteArrayOf(0x00, 0x01)   // HKDF-SHA256
+    private val AEAD_ID = byteArrayOf(0x00, 0x01)  // AES-128-GCM
+    private const val MODE_BASE: Byte = 0x00
+
+    private const val NSECRET = 32  // KEM shared secret length
+    private const val NK = 16       // AEAD key length (AES-128)
+    private const val NN = 12       // AEAD nonce length
+    private const val NH = 32       // HKDF-SHA256 output length
+
+    private const val HPKE_V1 = "HPKE-v1"
+
+    private val kemSuiteId: ByteArray = "KEM".toByteArray(Charsets.US_ASCII) + KEM_ID
+    private val hpkeSuiteId: ByteArray =
+        "HPKE".toByteArray(Charsets.US_ASCII) + KEM_ID + KDF_ID + AEAD_ID
 
     fun encrypt(
         plaintext: ByteArray,
@@ -21,24 +56,174 @@ object HPKEEncryptor {
         info: ByteArray
     ): HPKEEncryptionResult {
         try {
-            val hpke = HPKE(
-                HPKE.mode_base,
-                HPKE.kem_P256_SHA256,
-                HPKE.kdf_HKDF_SHA256,
-                HPKE.aead_AES_GCM128
-            )
+            val recipientPoint = recipientPublicKey.toUncompressedPoint()
 
-            val recipientPubKeyBytes = recipientPublicKey.toUncompressedPoint()
-            val recipientKey = hpke.deserializePublicKey(recipientPubKeyBytes)
+            // Generate the ephemeral P-256 key pair (skE, pkE)
+            val kpg = KeyPairGenerator.getInstance("EC")
+            kpg.initialize(ECGenParameterSpec("secp256r1"), SecureRandom())
+            val ephemeral = kpg.generateKeyPair()
+            val encPoint = serializePublicKey(ephemeral.public as ECPublicKey)
 
-            val senderContext = hpke.setupBaseS(recipientKey, info)
-
-            val enc = senderContext.encapsulation
-            val cipherText = senderContext.seal(ByteArray(0), plaintext)
-
-            return HPKEEncryptionResult(enc, cipherText)
+            return sealBase(recipientPoint, info, plaintext, ByteArray(0), ephemeral.private, encPoint)
         } catch (e: Exception) {
             throw DCAPIError.HPKEEncryptionFailed(e.message ?: "Unknown error")
         }
+    }
+
+    /**
+     * Test-only seam: lets the RFC 9180 vector tests inject a fixed ephemeral key (skE/pkE) and aad.
+     * Not used in production — [encrypt] always generates a fresh ephemeral key and empty aad.
+     */
+    internal fun sealBase(
+        recipientPointUncompressed: ByteArray,
+        info: ByteArray,
+        plaintext: ByteArray,
+        aad: ByteArray,
+        ephemeralPrivate: PrivateKey,
+        encPoint: ByteArray
+    ): HPKEEncryptionResult {
+        val recipientPublic = publicKeyFromPoint(recipientPointUncompressed)
+
+        // --- DHKEM Encap (RFC 9180 §4.1) ---
+        val dh = ecdh(ephemeralPrivate, recipientPublic)                 // P-256 DH = X coordinate (32 B)
+        val kemContext = encPoint + recipientPointUncompressed           // enc || pkRm
+        val sharedSecret = extractAndExpand(dh, kemContext)              // Nsecret bytes
+
+        // --- KeySchedule, mode_base (RFC 9180 §5.1) ---
+        val pskIdHash = labeledExtract(ByteArray(0), hpkeSuiteId, "psk_id_hash", ByteArray(0))
+        val infoHash = labeledExtract(ByteArray(0), hpkeSuiteId, "info_hash", info)
+        val keyScheduleContext = byteArrayOf(MODE_BASE) + pskIdHash + infoHash
+
+        val secret = labeledExtract(sharedSecret, hpkeSuiteId, "secret", ByteArray(0))
+        val key = labeledExpand(secret, hpkeSuiteId, "key", keyScheduleContext, NK)
+        val baseNonce = labeledExpand(secret, hpkeSuiteId, "base_nonce", keyScheduleContext, NN)
+
+        // --- Seal, sequence number 0 => nonce == base_nonce (RFC 9180 §5.2) ---
+        val cipherText = aesGcmSeal(key, baseNonce, aad, plaintext)
+        return HPKEEncryptionResult(encPoint, cipherText)
+    }
+
+    // ---- DHKEM ----
+
+    private fun extractAndExpand(dh: ByteArray, kemContext: ByteArray): ByteArray {
+        val eaePrk = labeledExtract(ByteArray(0), kemSuiteId, "eae_prk", dh)
+        return labeledExpand(eaePrk, kemSuiteId, "shared_secret", kemContext, NSECRET)
+    }
+
+    private fun ecdh(privateKey: PrivateKey, publicKey: ECPublicKey): ByteArray {
+        val ka = KeyAgreement.getInstance("ECDH")
+        ka.init(privateKey)
+        ka.doPhase(publicKey, true)
+        // For P-256 the ECDH shared secret is the X coordinate; normalise to 32 bytes.
+        return fixedLength(ka.generateSecret(), 32)
+    }
+
+    // ---- Labeled HKDF (RFC 9180 §4) ----
+
+    private fun labeledExtract(
+        salt: ByteArray,
+        suiteId: ByteArray,
+        label: String,
+        ikm: ByteArray
+    ): ByteArray {
+        val labeledIkm = HPKE_V1.toByteArray(Charsets.US_ASCII) +
+            suiteId + label.toByteArray(Charsets.US_ASCII) + ikm
+        return hkdfExtract(salt, labeledIkm)
+    }
+
+    private fun labeledExpand(
+        prk: ByteArray,
+        suiteId: ByteArray,
+        label: String,
+        info: ByteArray,
+        length: Int
+    ): ByteArray {
+        val labeledInfo = i2osp(length, 2) + HPKE_V1.toByteArray(Charsets.US_ASCII) +
+            suiteId + label.toByteArray(Charsets.US_ASCII) + info
+        return hkdfExpand(prk, labeledInfo, length)
+    }
+
+    // ---- HKDF-SHA256 (RFC 5869) ----
+
+    private fun hkdfExtract(salt: ByteArray, ikm: ByteArray): ByteArray {
+        // Empty salt == NH zero bytes (HMAC zero-pads the key to the block size anyway).
+        val key = if (salt.isEmpty()) ByteArray(NH) else salt
+        return hmacSha256(key, ikm)
+    }
+
+    private fun hkdfExpand(prk: ByteArray, info: ByteArray, length: Int): ByteArray {
+        val out = ByteArray(length)
+        var t = ByteArray(0)
+        var pos = 0
+        var i = 1
+        while (pos < length) {
+            t = hmacSha256(prk, t + info + byteArrayOf(i.toByte()))
+            val n = minOf(t.size, length - pos)
+            System.arraycopy(t, 0, out, pos, n)
+            pos += n
+            i++
+        }
+        return out
+    }
+
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    // ---- AEAD ----
+
+    private fun aesGcmSeal(key: ByteArray, nonce: ByteArray, aad: ByteArray, plaintext: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(128, nonce))
+        if (aad.isNotEmpty()) cipher.updateAAD(aad)
+        return cipher.doFinal(plaintext) // ciphertext || 16-byte tag
+    }
+
+    // ---- EC helpers ----
+
+    private val p256Params: ECParameterSpec by lazy {
+        val params = AlgorithmParameters.getInstance("EC")
+        params.init(ECGenParameterSpec("secp256r1"))
+        params.getParameterSpec(ECParameterSpec::class.java)
+    }
+
+    private fun publicKeyFromPoint(point: ByteArray): ECPublicKey {
+        require(point.size == 65 && point[0].toInt() == 0x04) { "Expected 65-byte uncompressed P-256 point" }
+        val x = BigInteger(1, point.copyOfRange(1, 33))
+        val y = BigInteger(1, point.copyOfRange(33, 65))
+        val spec = ECPublicKeySpec(ECPoint(x, y), p256Params)
+        return KeyFactory.getInstance("EC").generatePublic(spec) as ECPublicKey
+    }
+
+    private fun serializePublicKey(key: ECPublicKey): ByteArray {
+        val x = fixedLength(key.w.affineX.toByteArray(), 32)
+        val y = fixedLength(key.w.affineY.toByteArray(), 32)
+        return byteArrayOf(0x04) + x + y
+    }
+
+    // ---- byte utils ----
+
+    private fun i2osp(value: Int, length: Int): ByteArray {
+        val out = ByteArray(length)
+        var v = value
+        for (i in length - 1 downTo 0) {
+            out[i] = (v and 0xFF).toByte()
+            v = v ushr 8
+        }
+        return out
+    }
+
+    /** Left-trim sign bytes / left-pad with zeros to exactly [length] bytes. */
+    private fun fixedLength(value: ByteArray, length: Int): ByteArray {
+        if (value.size == length) return value
+        val out = ByteArray(length)
+        if (value.size > length) {
+            System.arraycopy(value, value.size - length, out, 0, length)
+        } else {
+            System.arraycopy(value, 0, out, length - value.size, value.size)
+        }
+        return out
     }
 }

--- a/eudi-wallet-oidc-android/src/test/java/com/ewc/eudi_wallet_oidc_android/dcapi/HPKEEncryptorTest.kt
+++ b/eudi-wallet-oidc-android/src/test/java/com/ewc/eudi_wallet_oidc_android/dcapi/HPKEEncryptorTest.kt
@@ -1,0 +1,69 @@
+package com.ewc.eudi_wallet_oidc_android.dcapi
+
+import com.ewc.eudi_wallet_oidc_android.services.dcapi.HPKEEncryptor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.KeyFactory
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPrivateKeySpec
+
+/**
+ * Validates the pure-JCA [HPKEEncryptor] against the official RFC 9180 Appendix A.3.1 test vectors:
+ * DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM, mode Base.
+ *
+ * The fixed ephemeral key (skEm) and aad from the RFC are injected via the internal seam so that
+ * the output is fully deterministic and can be checked byte-for-byte against the RFC's enc and ct.
+ */
+class HPKEEncryptorTest {
+
+    // RFC 9180 A.3.1
+    private val info = hex("4f6465206f6e2061204772656369616e2055726e")
+    private val skEm = hex("4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb")
+    private val pkEm = hex(
+        "04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325a" +
+        "c98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4"
+    )
+    private val pkRm = hex(
+        "04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f706a" +
+        "826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0"
+    )
+    // A.3.1.1, sequence number 0
+    private val pt = hex("4265617574792069732074727574682c20747275746820626561757479")
+    private val aad = hex("436f756e742d30")
+    private val ct = hex(
+        "5ad590bb8baa577f8619db35a36311226a896e7342a6d836d8b7bcd2f20b6c7f" +
+        "9076ac232e3ab2523f39513434"
+    )
+
+    @Test
+    fun matchesRfc9180A31BaseVector() {
+        val ephemeralPrivate = ecPrivateKeyFromScalar(skEm)
+
+        val result = HPKEEncryptor.sealBase(
+            recipientPointUncompressed = pkRm,
+            info = info,
+            plaintext = pt,
+            aad = aad,
+            ephemeralPrivate = ephemeralPrivate,
+            encPoint = pkEm
+        )
+
+        assertEquals("enc mismatch", pkEm.toHex(), result.encapsulatedKey.toHex())
+        assertEquals("ciphertext mismatch", ct.toHex(), result.cipherText.toHex())
+    }
+
+    private fun ecPrivateKeyFromScalar(scalar: ByteArray): java.security.PrivateKey {
+        val params = AlgorithmParameters.getInstance("EC").apply { init(ECGenParameterSpec("secp256r1")) }
+            .getParameterSpec(ECParameterSpec::class.java)
+        val spec = ECPrivateKeySpec(BigInteger(1, scalar), params)
+        return KeyFactory.getInstance("EC").generatePrivate(spec)
+    }
+
+    private fun hex(s: String): ByteArray =
+        ByteArray(s.length / 2) { ((s[it * 2].digitToInt(16) shl 4) or s[it * 2 + 1].digitToInt(16)).toByte() }
+
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+}


### PR DESCRIPTION
The DC-API / ISO 18013-7 Annex C HPKE encryptor was the SDK's only BouncyCastle usage. Reimplement it with the platform JCA (DHKEM(P-256, HKDF-SHA256) / HKDF-SHA256 / AES-128-GCM, mode Base) and drop the bcprov-jdk18on dependency. Validated byte-for-byte against the RFC 9180 Appendix A.3.1 test vectors.
