### PR TITLE
Fix #655 : Send the full x5c chain to the trust-list lookup

### DIFF
--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/ServerTrustMechanismService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/ServerTrustMechanismService.kt
@@ -72,9 +72,10 @@ class ServerTrustMechanismService(
         url: String?,
         x5c: String?,
         trustProvidersList: List<TrustServiceProvider>?,
-        isDCQLVerificationFlow: Boolean
+        isDCQLVerificationFlow: Boolean,
+        x5cChain: List<String>?
     ): Boolean {
-        val response = lookup(x5c) ?: return false
+        val response = lookup(x5c, x5cChain) ?: return false
 
         logDroppedEntries(response)
 
@@ -89,9 +90,10 @@ class ServerTrustMechanismService(
     override suspend fun fetchTrustDetails(
         url: String?,
         x5c: String?,
-        trustProvidersList: List<TrustServiceProvider>?
+        trustProvidersList: List<TrustServiceProvider>?,
+        x5cChain: List<String>?
     ): TrustServiceProvider? {
-        val response = lookup(x5c) ?: return null
+        val response = lookup(x5c, x5cChain) ?: return null
         if (!response.match) return null
         logDroppedEntries(response)
         val entries = response.grantedEntries
@@ -119,14 +121,29 @@ class ServerTrustMechanismService(
             }
     }
 
-    /** POST /trust-list/lookup (open endpoint). Fail-closed to null. */
-    private suspend fun lookup(x5c: String?): TrustListLookupResponse? {
-        if (x5c.isNullOrBlank()) {
+    /**
+     * POST /trust-list/lookup (open endpoint). Fail-closed to null.
+     *
+     * [chain] is the request's full certificate chain, leaf first. When present it is posted whole,
+     * so the backend can match an entry registered against the CA or an intermediate rather than the
+     * leaf, and report which one hit via `matchedCertIndex`. Otherwise the single [x5c] identifier is
+     * routed to the field its shape implies (x5c / did / kid).
+     */
+    private suspend fun lookup(x5c: String?, chain: List<String>? = null): TrustListLookupResponse? {
+        val certChain = chain?.filter { it.isNotBlank() }.orEmpty()
+        if (certChain.isEmpty() && x5c.isNullOrBlank()) {
             Log.e(TAG, "No identifier supplied; failing closed")
             return null
         }
-        val body = buildLookupRequest(x5c)
-        Log.d(TAG, "Trust lookup by ${if (body.x5c != null) "x5c" else if (body.did != null) "did" else "kid"}")
+        val body = if (certChain.isNotEmpty()) {
+            Log.d(TAG, "Trust lookup by x5c chain of ${certChain.size} certificate(s), leaf first")
+            TrustListLookupRequest(x5c = certChain)
+        } else {
+            buildLookupRequest(x5c!!)
+        }
+        if (certChain.isEmpty()) {
+            Log.d(TAG, "Trust lookup by ${if (body.x5c != null) "x5c" else if (body.did != null) "did" else "kid"}")
+        }
 
         val response = try {
             ApiManager.api.getService()?.trustListLookup(lookupUrl, body)

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustEvaluator.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustEvaluator.kt
@@ -118,14 +118,23 @@ object TrustEvaluator {
      */
     private fun trustMechanism(): TrustMechanismInterface = ServerTrustMechanismService()
 
+    /**
+     * @param x5cChain full certificate chain from the request, leaf first. Pass it whenever the
+     * request carries more than the signing certificate — a trust list may register the CA or an
+     * intermediate rather than the leaf, and only a lookup that sees the whole chain matches those.
+     * [x5cCert] alone still works and is treated as a one-certificate chain.
+     */
      suspend fun isTrusted(
          x5cCert: String?,
          url: String? = null,
          trustProvidersList: List<TrustServiceProvider>? = null,
-         isDCQLVerificationFlow: Boolean = false
+         isDCQLVerificationFlow: Boolean = false,
+         x5cChain: List<String>? = null
      ): Boolean {
-        x5cCert ?: return false
-        return trustMechanism().isIssuerOrVerifierTrusted(url, x5cCert, trustProvidersList, isDCQLVerificationFlow)
+        if (x5cCert == null && x5cChain.isNullOrEmpty()) return false
+        return trustMechanism().isIssuerOrVerifierTrusted(
+            url, x5cCert, trustProvidersList, isDCQLVerificationFlow, x5cChain
+        )
     }
 
      fun extractBase64PublicKeyFromX5C(x5cBase64: String): String? {

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustMechanismInterface.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustMechanismInterface.kt
@@ -3,16 +3,26 @@ package com.ewc.eudi_wallet_oidc_android.services.trust
 import com.ewc.eudi_wallet_oidc_android.models.TrustServiceProvider
 
 interface TrustMechanismInterface {
+    /**
+     * @param x5cChain the full certificate chain from the request, **leaf first** (as in a JWS `x5c`
+     * header or a COSE `x5chain`). Supply this whenever the request carries more than the signing
+     * certificate: a trust list may register the CA or an intermediate rather than the leaf, and only
+     * a lookup that sees the whole chain can match such an entry. When null (or empty) the lookup
+     * falls back to the single [x5c] identifier.
+     */
     suspend fun isIssuerOrVerifierTrusted(
         url: String? = null,
         x5c: String? = null,
         trustProvidersList: List<TrustServiceProvider>? = null,
-        isDCQLVerificationFlow: Boolean = false
+        isDCQLVerificationFlow: Boolean = false,
+        x5cChain: List<String>? = null
     ): Boolean
 
+    /** @param x5cChain see [isIssuerOrVerifierTrusted]; full chain, leaf first. */
     suspend fun fetchTrustDetails(
         url: String? = null,
         x5c: String? = null,
-        trustProvidersList: List<TrustServiceProvider>? = null
+        trustProvidersList: List<TrustServiceProvider>? = null,
+        x5cChain: List<String>? = null
     ): TrustServiceProvider?
 }

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustMechanismService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustMechanismService.kt
@@ -19,12 +19,19 @@ class TrustMechanismService : TrustMechanismInterface {
     val gson = GsonBuilder()
         .registerTypeAdapter(TrustServiceProvider::class.java, TrustServiceProviderDeserializer())
         .create()
+    /**
+     * [x5cChain] is accepted for interface parity with [ServerTrustMechanismService] but only its
+     * leaf is used: local TSL matching compares one certificate against the list, it has no notion of
+     * matching further up the chain.
+     */
     override suspend fun isIssuerOrVerifierTrusted(
         url: String?,
         x5c: String?,
         trustProvidersList: List<TrustServiceProvider>?,
-        isDCQLVerificationFlow: Boolean
+        isDCQLVerificationFlow: Boolean,
+        x5cChain: List<String>?
     ): Boolean {
+        @Suppress("NAME_SHADOWING") val x5c = x5c ?: x5cChain?.firstOrNull()
         // 1. First preference: Check the cached providers if available
         if (!trustProvidersList.isNullOrEmpty()) {
             Log.d(TAG, "Using cached providers for validation.")
@@ -84,11 +91,14 @@ class TrustMechanismService : TrustMechanismInterface {
     }
 
 
+    /** [x5cChain] — see [isIssuerOrVerifierTrusted]; the local list matches on the leaf only. */
     override suspend fun fetchTrustDetails(
         url: String?,
         x5c: String?,
-        trustProvidersList: List<TrustServiceProvider>?
+        trustProvidersList: List<TrustServiceProvider>?,
+        x5cChain: List<String>?
     ): TrustServiceProvider? {
+        @Suppress("NAME_SHADOWING") val x5c = x5c ?: x5cChain?.firstOrNull()
         // 1. First preference: Check the cached providers if available
         if (!trustProvidersList.isNullOrEmpty()) {
             Log.d(TAG, "Using cached providers to find trust details.")


### PR DESCRIPTION
The lookup posted a single certificate — the leaf — so a verifier whose CA or intermediate is registered in the trust list, rather than its leaf, resolved as untrusted. The backend was already built for chains: the request field is x5c: List<String>, and the response carries certificateDetails plus matchedCertIndex, which mapToTspService() already reads to pick the matching subjectKeyIdentifier. That index is meaningless while only one certificate is posted.

Adds an optional x5cChain: List<String>? (leaf first) to TrustMechanismInterface, ServerTrustMechanismService and TrustEvaluator.isTrusted, defaulting to null so every existing caller is source-compatible and produces the identical request. ServerTrustMechanismService.lookup() posts the chain whole when present and keeps the single-identifier routing (x5c / did / kid) otherwise.

TrustMechanismService (legacy local TSL) takes the parameter for interface parity only: local matching compares one certificate against the list and has no notion of matching further up the chain, so it uses the leaf.

Note this is binary-incompatible — the JVM signatures gain a parameter — so consumers must recompile against the new version.