### PR TITLE
Fix #659 : Disable SDK logging by default and add a configurable Logger

### DIFF
--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/logging/Logger.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/logging/Logger.kt
@@ -1,0 +1,170 @@
+package com.ewc.eudi_wallet_oidc_android.logging
+
+import android.util.Log
+import okhttp3.logging.HttpLoggingInterceptor
+
+/**
+ * Logging for the SDK. **Silent until the host turns it on.**
+ *
+ * Everything this SDK handles is confidential — issued credentials, access and refresh tokens, DPoP
+ * proofs, wallet attestations, PID attributes. Anything written to logcat is readable by any app
+ * holding `READ_LOGS`, by adb, and by some device log collectors, so a library has no business
+ * logging by default.
+ *
+ * The shape follows what OkHttp's `HttpLoggingInterceptor`, Coil and Ktor do: a level, a sink the
+ * host supplies, and off unless asked. A host that already has a logging stack (Timber, Crashlytics,
+ * a file) implements [Sink] and everything routes there instead of logcat.
+ *
+ * ```kotlin
+ * // Application.onCreate — debug builds only
+ * Logger.configure(
+ *     level = Logger.Level.DEBUG,
+ *     networkLevel = Logger.NetworkLevel.BODY,
+ * )
+ *
+ * // or route into the host's own logger
+ * Logger.configure(
+ *     level = Logger.Level.DEBUG,
+ *     sink = Logger.Sink { priority, tag, message, t -> Timber.log(priority, t, message) },
+ * )
+ * ```
+ *
+ * Deliberately **not** driven by the SDK's own `BuildConfig.DEBUG`: in a published AAR that is
+ * always `false` regardless of how the host was built, so it would disable logging for everyone.
+ */
+object Logger {
+
+    /** Severity gate for the SDK's own messages. [NONE] disables them entirely. */
+    enum class Level(internal val priority: Int) {
+        NONE(Int.MAX_VALUE),
+        ERROR(Log.ERROR),
+        WARN(Log.WARN),
+        INFO(Log.INFO),
+        DEBUG(Log.DEBUG),
+        VERBOSE(Log.VERBOSE),
+    }
+
+    /** How much of each HTTP call is logged. Mirrors `HttpLoggingInterceptor.Level`. */
+    enum class NetworkLevel {
+        /** No network logging. */
+        NONE,
+
+        /** Method, URL, status, size. */
+        BASIC,
+
+        /** BASIC plus headers, with the sensitive ones redacted. */
+        HEADERS,
+
+        /**
+         * HEADERS plus full bodies. Buffers each response into memory and copies it to a String, so
+         * expect roughly twice the payload in transient heap per call — issuer metadata alone can
+         * be hundreds of KB. Debug builds only.
+         */
+        BODY,
+    }
+
+    /** Where log lines go. Implement to route into the host's own logging stack. */
+    fun interface Sink {
+        fun log(priority: Int, tag: String, message: String, throwable: Throwable?)
+    }
+
+    /** Default sink — plain `android.util.Log`. */
+    @JvmField
+    val AndroidLogSink = Sink { priority, tag, message, throwable ->
+        if (throwable != null) Log.println(priority, tag, "$message\n${Log.getStackTraceString(throwable)}")
+        else Log.println(priority, tag, message)
+    }
+
+    @Volatile
+    var level: Level = Level.NONE
+        private set
+
+    @Volatile
+    var networkLevel: NetworkLevel = NetworkLevel.NONE
+        private set
+
+    @Volatile
+    private var sink: Sink = AndroidLogSink
+
+    /**
+     * The interceptor `ApiManager` installs. Owned here so [configure] applies whether it is called
+     * before or after the HTTP client is first built. Sensitive headers are redacted even at
+     * [NetworkLevel.BODY] — the body may still carry secrets, which is why BODY is debug-only.
+     */
+    @JvmStatic
+    val networkInterceptor: HttpLoggingInterceptor =
+        HttpLoggingInterceptor(object : HttpLoggingInterceptor.Logger {
+            override fun log(message: String) {
+                // Routed through the host's sink rather than straight to logcat, so network lines
+                // land wherever the SDK's own messages do.
+                sink.log(Log.DEBUG, "SdkNetwork", message, null)
+            }
+        }).apply {
+            setLevel(HttpLoggingInterceptor.Level.NONE)
+            redactHeader("Authorization")
+            redactHeader("DPoP")
+            redactHeader("Cookie")
+            redactHeader("Set-Cookie")
+        }
+
+    /**
+     * Turns logging on. Call once at startup, from a debug path only.
+     *
+     * @param level severity gate for the SDK's own messages.
+     * @param networkLevel how much of each HTTP call to log.
+     * @param sink where lines go; defaults to logcat.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun configure(
+        level: Level = Level.NONE,
+        networkLevel: NetworkLevel = NetworkLevel.NONE,
+        sink: Sink = AndroidLogSink,
+    ) {
+        this.level = level
+        this.sink = sink
+        this.networkLevel = networkLevel
+        networkInterceptor.setLevel(
+            when (networkLevel) {
+                NetworkLevel.NONE -> HttpLoggingInterceptor.Level.NONE
+                NetworkLevel.BASIC -> HttpLoggingInterceptor.Level.BASIC
+                NetworkLevel.HEADERS -> HttpLoggingInterceptor.Level.HEADERS
+                NetworkLevel.BODY -> HttpLoggingInterceptor.Level.BODY
+            }
+        )
+    }
+
+    /** Convenience for the common case: everything on, or everything off. */
+    @JvmStatic
+    fun setEnabled(enabled: Boolean) {
+        if (enabled) configure(Level.DEBUG, NetworkLevel.BODY) else configure()
+    }
+
+    // MARK: - Internal call sites -----------------------------------------
+
+    @JvmStatic
+    fun v(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.VERBOSE, tag, message, throwable)
+
+    @JvmStatic
+    fun d(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.DEBUG, tag, message, throwable)
+
+    @JvmStatic
+    fun i(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.INFO, tag, message, throwable)
+
+    @JvmStatic
+    fun w(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.WARN, tag, message, throwable)
+
+    @JvmStatic
+    fun e(tag: String, message: String, throwable: Throwable? = null) =
+        log(Log.ERROR, tag, message, throwable)
+
+    private fun log(priority: Int, tag: String, message: String, throwable: Throwable?) {
+        val gate = level
+        if (gate == Level.NONE || priority < gate.priority) return
+        sink.log(priority, tag, message, throwable)
+    }
+}

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiManager.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiManager.kt
@@ -2,7 +2,7 @@ package com.ewc.eudi_wallet_oidc_android.services.network
 
 import com.google.gson.GsonBuilder
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
+import com.ewc.eudi_wallet_oidc_android.logging.Logger
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.security.SecureRandom
@@ -24,27 +24,6 @@ object ApiManager {
 
     private var apiManager: ApiManager? = null
 
-    /** Kept so [setNetworkLoggingEnabled] works whether it is called before or after first use. */
-    private val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.NONE
-    }
-
-    /**
-     * Full request/response logging. **Off by default** — the traffic on this client carries
-     * credentials, access and refresh tokens and PID attributes, and `Level.BODY` writes all of it
-     * to logcat, readable by anything with `READ_LOGS` or adb. It also buffers every response body
-     * into memory and copies it to a String, which on large issuer metadata is megabytes of heap
-     * per request.
-     *
-     * A library's own `BuildConfig.DEBUG` is false in a published AAR regardless of the host's
-     * build type, so this is an explicit opt-in rather than an automatic debug check. Host apps
-     * should enable it only in debug builds.
-     */
-    fun setNetworkLoggingEnabled(enabled: Boolean) {
-        httpLoggingInterceptor.level =
-            if (enabled) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
-    }
-
     fun getService(): ApiService? {
         return service
     }
@@ -55,7 +34,9 @@ object ApiManager {
                 apiManager = ApiManager
                 httpClient = OkHttpClient.Builder()
                 httpClient?.followRedirects(false)
-                httpClient!!.addInterceptor(httpLoggingInterceptor)
+                // Silent unless the host called Logger.configure(...). Owned by Logger so the
+                // level can change after this client is built.
+                httpClient!!.addInterceptor(Logger.networkInterceptor)
                 okClient = httpClient!!.readTimeout(120, TimeUnit.SECONDS)
                     .connectTimeout(120, TimeUnit.SECONDS).build()
                 val gson = GsonBuilder()

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiManager.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiManager.kt
@@ -24,6 +24,27 @@ object ApiManager {
 
     private var apiManager: ApiManager? = null
 
+    /** Kept so [setNetworkLoggingEnabled] works whether it is called before or after first use. */
+    private val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.NONE
+    }
+
+    /**
+     * Full request/response logging. **Off by default** — the traffic on this client carries
+     * credentials, access and refresh tokens and PID attributes, and `Level.BODY` writes all of it
+     * to logcat, readable by anything with `READ_LOGS` or adb. It also buffers every response body
+     * into memory and copies it to a String, which on large issuer metadata is megabytes of heap
+     * per request.
+     *
+     * A library's own `BuildConfig.DEBUG` is false in a published AAR regardless of the host's
+     * build type, so this is an explicit opt-in rather than an automatic debug check. Host apps
+     * should enable it only in debug builds.
+     */
+    fun setNetworkLoggingEnabled(enabled: Boolean) {
+        httpLoggingInterceptor.level =
+            if (enabled) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+    }
+
     fun getService(): ApiService? {
         return service
     }
@@ -34,8 +55,6 @@ object ApiManager {
                 apiManager = ApiManager
                 httpClient = OkHttpClient.Builder()
                 httpClient?.followRedirects(false)
-                val httpLoggingInterceptor = HttpLoggingInterceptor()
-                httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
                 httpClient!!.addInterceptor(httpLoggingInterceptor)
                 okClient = httpClient!!.readTimeout(120, TimeUnit.SECONDS)
                     .connectTimeout(120, TimeUnit.SECONDS).build()

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/notification/NotificationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/notification/NotificationService.kt
@@ -1,6 +1,7 @@
 package com.ewc.eudi_wallet_oidc_android.services.notification
 
 import android.util.Log
+import com.ewc.eudi_wallet_oidc_android.logging.Logger
 import com.ewc.eudi_wallet_oidc_android.models.WrappedRefreshTokenResponse
 import com.ewc.eudi_wallet_oidc_android.models.ErrorResponse
 import com.ewc.eudi_wallet_oidc_android.models.NotificationRequest
@@ -33,10 +34,11 @@ class NotificationService : NotificationServiceInterface {
             Log.e("sendNotificationRequest", "Invalid input parameters, request aborted.")
             return // Exit early if any input is missing
         }
-        Log.d("sendNotificationRequest", "Endpoint: $notificationEndPoint")
-        Log.d("sendNotificationRequest", "Authorization: Bearer $accessToken")
-        Log.d("sendNotificationRequest", "Event: ${event.value}")
-        Log.d("sendNotificationRequest", "NotificationId: $notificationId")
+        Logger.d("sendNotificationRequest", "Endpoint: $notificationEndPoint")
+        // The token itself is never logged; Logger.networkInterceptor redacts the header too.
+        Logger.d("sendNotificationRequest", "Authorization: Bearer <redacted>")
+        Logger.d("sendNotificationRequest", "Event: ${event.value}")
+        Logger.d("sendNotificationRequest", "NotificationId: $notificationId")
 
         // Use safeApiCallResponse wrapper
         val result = SafeApiCall.safeApiCallResponse {


### PR DESCRIPTION
ApiManager set HttpLoggingInterceptor to Level.BODY unconditionally, so every consuming app got full request and response logging in release builds too. Everything on this client is confidential — issued credentials, access and refresh tokens, DPoP proofs, wallet attestations and PID attributes — and Level.BODY writes all of it to logcat, readable by anything holding READ_LOGS or with adb access. It also pulls each response into a Buffer and builds a String copy of it, roughly twice the payload in transient heap per call, which is most noticeable on the issuer metadata endpoint that is re-fetched on every issuance.

Default to Level.NONE and add setNetworkLoggingEnabled(...) for hosts that want it back. The interceptor is now a field rather than a local so the setter applies whether it is called before or after the client is first built.

Opt-in rather than a BuildConfig.DEBUG check: a library's BuildConfig.DEBUG reflects how the library was built, not the host, and is always false in a published AAR — a debug check here would disable logging for everyone including SDK developers. This matches the configuration style already used by ServerTrustMechanismService.init(...).