### PR TITLE
Fix #667 : ARF TS3 wallet unit and key attestation, and OpenID4VCI 1.0 interoperability

### DIFF
--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/models/ClientAssertion.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/models/ClientAssertion.kt
@@ -4,5 +4,8 @@ import com.google.gson.annotations.SerializedName
 
 data class ClientAssertion(
     @SerializedName("client_assertion") var clientAssertion: String? = null,
-    @SerializedName("client_assertion_type") var clientAssertionType: String? = null
+    @SerializedName("client_assertion_type") var clientAssertionType: String? = null,
+    // ARF TS3 v1.5 opt-in: "ts3" requests a TS3-shaped WIA (x5c identity,
+    // client_status). Null keeps the legacy EWC shape and is omitted on the wire.
+    @SerializedName("profile") var profile: String? = null
 )

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/models/KeyAttestation.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/models/KeyAttestation.kt
@@ -1,0 +1,19 @@
+package com.ewc.eudi_wallet_oidc_android.models
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Request body of the wallet-provider key-attestation endpoint
+ * (POST {baseUrl}/wallet-provider/key-attestation, ARF TS3 v1.5).
+ */
+data class KeyAttestationRequest(
+    @SerializedName("attested_keys") var attestedKeys: List<Map<String, Any>>? = null,
+    @SerializedName("android_key_attestation_x5c") var androidKeyAttestationX5c: List<String>? = null,
+    @SerializedName("key_pops") var keyPops: List<String>? = null
+)
+
+data class KeyAttestationResponse(
+    @SerializedName("keyAttestation") var keyAttestation: String? = null,
+    @SerializedName("attestationType") var attestationType: String? = null,
+    @SerializedName("keyStorage") var keyStorage: List<String>? = null
+)

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/CredentialRevocationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/CredentialRevocationService.kt
@@ -40,8 +40,9 @@ class CredentialRevocationService : CredentialRevocationServiceInterface{
                         statusList2021.add(credential)
                     }
 
-                    // ✅ Safe check for status.status_list
-                    val status = jsonPayload.getAsJsonObject("status")
+                    // ✅ Safe check for status.status_list (or the TS3 WIA
+                    // location, see StatusClaims)
+                    val status = StatusClaims.of(jsonPayload)
                     val statusList = status?.getAsJsonObject("status_list")
                     if (statusList != null) {
                         ietfStatusList.add(credential)

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/IETFTokenStatusList.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/IETFTokenStatusList.kt
@@ -54,7 +54,7 @@ class IETFTokenStatusList: StatusListInterface {
                     return null
                 }
 
-                val status = jsonPayload.getAsJsonObject("status") ?: run {
+                val status = StatusClaims.of(jsonPayload) ?: run {
                     Log.e("Error", "'status' field not found in JWT payload.")
                     return null
                 }

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/StatusClaims.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/credentialRevocation/StatusClaims.kt
@@ -1,0 +1,15 @@
+package com.ewc.eudi_wallet_oidc_android.services.credentialRevocation
+
+import com.google.gson.JsonObject
+
+/**
+ * Single home for locating the status claim of a credential JWT payload:
+ * the classic top-level "status", or "client_status.status" on an
+ * ARF TS3 v1.5 Wallet Instance Attestation.
+ */
+object StatusClaims {
+    fun of(payload: JsonObject): JsonObject? {
+        return payload.getAsJsonObject("status")
+            ?: payload.getAsJsonObject("client_status")?.getAsJsonObject("status")
+    }
+}

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
@@ -311,10 +311,13 @@ class IssueService : IssueServiceInterface {
                 "client_metadata" to clientMetadata,
                 "issuer_state" to (credentialOffer?.grants?.authorizationCode?.issuerState ?: "")
             )
+            Log.d("BankIdWatch", "PAR POST ${authConfig.pushedAuthorizationRequestEndpoint}")
             headers.forEach { (k, v) ->
                 v.chunked(3000).forEachIndexed { i, chunk ->
+                    Log.d("BankIdWatch", "PAR header $k[$i]=$chunk")
                 }
             }
+            parParams.forEach { (k, v) -> Log.d("BankIdWatch", "PAR param $k=$v") }
             val result = SafeApiCall.safeApiCallResponse {
                 ApiManager.api.getService()?.processParAuthorisationRequest(
                     authConfig.pushedAuthorizationRequestEndpoint ?: "",
@@ -327,6 +330,7 @@ class IssueService : IssueServiceInterface {
                 onSuccess = { parResponse ->
                     if (parResponse.isSuccessful) {
                         val requestUri = parResponse.body()?.requestUri ?: ""
+                        Log.d("BankIdWatch", "PAR response code=${parResponse.code()} request_uri=$requestUri Set-Cookie=${parResponse.headers().values("Set-Cookie")}")
                         if (isApiCallRequired) {
                             val nextResult = SafeApiCall.safeApiCallResponse {
                                 ApiManager.api.getService()?.processAuthorisationRequest(
@@ -338,12 +342,18 @@ class IssueService : IssueServiceInterface {
                             nextResult.fold(
                                 onSuccess = { response ->
                                     val location = response.headers()["Location"]
+                                    Log.d("BankIdWatch", "authorize GET $authorisationEndPoint request_uri=$requestUri")
+                                    Log.d("BankIdWatch", "authorize response code=${response.code()} Location=$location")
+                                    Log.d("BankIdWatch", "authorize Set-Cookie=${response.headers().values("Set-Cookie")}")
                                     if (response.code() == 302 && !location.isNullOrEmpty()) {
+                                        Log.d("BankIdWatch", "returning Location AS-IS to caller: $location")
                                         return location
                                     } else if (response.isSuccessful && response.headers()["Content-Type"]?.contains("text/html") == true) {
+                                        Log.d("BankIdWatch", "html branch, returning final request url: ${response.raw().request.url}")
                                         return response.raw().request.url.toString()
                                     } else if ((response.code()) >= 400) {
                                         val errorMessage = response.errorBody()?.string() ?: "Unexpected error."
+                                        Log.d("BankIdWatch", "error branch code=${response.code()} body=$errorMessage")
                                         val urlBuilder = Uri.parse(authorisationEndPoint ?: "").buildUpon()
                                         urlBuilder.appendQueryParameter("error", errorMessage)
                                         return urlBuilder.build().toString()
@@ -351,6 +361,7 @@ class IssueService : IssueServiceInterface {
                                 },
                                 onFailure = { error ->
                                     Log.e(TAG, "PAR follow-up failed: ${error.message}")
+                                    Log.e("BankIdWatch", "authorize call failed: ${error.message}")
                                 }
                             )
                         } else {
@@ -923,11 +934,13 @@ class IssueService : IssueServiceInterface {
         }
 
         val credentialEncryptionBuilder = CredentialEncryptionBuilder()
-        // ARF TS3 v1.5: the KA travels in the proof's key_attestation header,
-        // bound to the same c_nonce as the proof.
+        // ARF TS3 v1.5: the wallet-provider-issued KA travels in the proof's
+        // key_attestation header, bound to the same c_nonce as the proof.
         val keyAttestation = KeyAttestationService.forProof(
-            keyAttestationJwt, attachKeyAttestation, subJwk, nonce
+            keyAttestationJwt, attachKeyAttestation
         )
+        Log.d("BankIdWatch", "credential request: attachKA=$attachKeyAttestation preMintedHardwareKA=${keyAttestationJwt != null} kaAttached=${keyAttestation != null} cNonce=$nonce auth=${if (dpopHeaderValue != null) "DPoP" else "Bearer"} endpoint=${issuerConfig?.credentialEndpoint}")
+        Log.d("KaWatch", "credential request: attachKA=$attachKeyAttestation preMintedKA=${keyAttestationJwt != null} kaOnProof=${keyAttestation != null} cNonce=$nonce auth=${if (dpopHeaderValue != null) "DPoP" else "Bearer"} endpoint=${issuerConfig?.credentialEndpoint}")
         val jwt = ProofService().createProof(did, subJwk, nonce , issuerConfig,credentialOffer,index, keyAttestation)
         if (jwt == null) {
             Log.e("IssueService", "Failed to create proof for credential request")
@@ -991,6 +1004,7 @@ class IssueService : IssueServiceInterface {
         request.credentialResponseEncryption = credentialEncryptionBuilder.build(ecKeyWithAlgEnc)
 
         Gson().toJson(request).chunked(3000).forEachIndexed { i, chunk ->
+            Log.d("BankIdWatch", "credential request body[$i]=$chunk")
         }
 
         // Safely perform network call using SafeApiCall
@@ -1030,8 +1044,10 @@ class IssueService : IssueServiceInterface {
                 when {
                     (response.code() >= 400) -> {
                         try {
+                            val errorBody = response.errorBody()?.string()
+                            Log.e("KaWatch", "credential endpoint ${response.code()}: $errorBody")
                             WrappedCredentialResponse(
-                                errorResponse = ErrorHandler.processError(response.errorBody()?.string())
+                                errorResponse = ErrorHandler.processError(errorBody)
                             )
                         } catch (e: Exception) {
                             null
@@ -1039,6 +1055,7 @@ class IssueService : IssueServiceInterface {
                     }
 
                     response.isSuccessful -> {
+                        Log.d("KaWatch", "credential endpoint ${response.code()}: success")
                         parseCredentialResponse(response, ecKeyWithAlgEnc, credentialEncryptionBuilder)
                     }
 

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
@@ -38,7 +38,6 @@ import com.ewc.eudi_wallet_oidc_android.services.verification.authorisationRespo
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
-import com.google.gson.JsonObject
 import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import com.nimbusds.jose.JOSEObjectType
@@ -60,7 +59,8 @@ import org.json.JSONObject
 import retrofit2.Response
 import java.util.Date
 import java.util.UUID
-import android.util.Base64
+import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.KeyAttestationService
+import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.WalletUnitAttestationHeaders
 import com.ewc.eudi_wallet_oidc_android.models.CredentialRequestEncryptionInfo
 import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall
 import com.ewc.eudi_wallet_oidc_android.services.utils.DPoPProofService
@@ -197,14 +197,10 @@ class IssueService : IssueServiceInterface {
         walletUnitAttestationJWT: String? ,
         walletUnitProofOfPossession: String?,
     ): String? {
-        val headers = mutableMapOf<String, String>().apply {
-            if (!walletUnitAttestationJWT.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation"] = walletUnitAttestationJWT.removeSuffix("~")
-            }
-            if (!walletUnitProofOfPossession.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation-PoP"] = walletUnitProofOfPossession
-            }
-        }
+        val headers = WalletUnitAttestationHeaders.build(
+            walletUnitAttestationJWT,
+            walletUnitProofOfPossession
+        )
         val TAG = "iar"
         val authorisationEndPoint =authConfig?.authorizationEndpoint
         val responseType = "code"
@@ -216,7 +212,7 @@ class IssueService : IssueServiceInterface {
         }
         val state = UUID.randomUUID().toString()
         //val clientId = did
-        val clientId = extractSubFromJwt(walletUnitAttestationJWT) ?: did
+        val clientId = WalletUnitAttestationHeaders.clientId(walletUnitAttestationJWT, did)
         val authorisationDetails = buildAuthorizationRequest(
             credentialOffer = credentialOffer,
             format = format,
@@ -469,27 +465,6 @@ class IssueService : IssueServiceInterface {
         return null
     }
 
-    private fun extractSubFromJwt(jwt: String?): String? {
-        try {
-            if (jwt.isNullOrEmpty()) return null
-
-            val parts = jwt.split(".")
-            if (parts.size < 2) return null
-
-            val payload = parts[1]
-            // Base64 decode payload (URL-safe, no padding)
-            val decodedBytes = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
-            val payloadJson = String(decodedBytes, Charsets.UTF_8)
-
-            // Parse JSON
-            val jsonObject = Gson().fromJson(payloadJson, JsonObject::class.java)
-            return jsonObject.get("sub")?.asString
-        } catch (e: Exception) {
-            return null
-        }
-    }
-
-
     suspend fun processAuthorisationRequestUsingIdToken(
         did: String?,
         authorisationEndPoint: String?,
@@ -701,13 +676,10 @@ class IssueService : IssueServiceInterface {
                 dpopKey = dpopKey
             )
         } else null
-        val headers = mutableMapOf<String, String>().apply {
-            if (!walletUnitAttestationJWT.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation"] = walletUnitAttestationJWT.removeSuffix("~")
-            }
-            if (!walletUnitProofOfPossession.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation-PoP"] = walletUnitProofOfPossession
-            }
+        val headers = WalletUnitAttestationHeaders.build(
+            walletUnitAttestationJWT,
+            walletUnitProofOfPossession
+        ).apply {
             if (!dpop.isNullOrEmpty()) {
                 this["DPoP"] = dpop
             }
@@ -914,9 +886,11 @@ class IssueService : IssueServiceInterface {
         ecKeyWithAlgEnc:ECKeyWithAlgEnc?,
         credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
         authConfig: AuthorisationServerWellKnownConfiguration?,
-        dpopKey: ECKey?
+        dpopKey: ECKey?,
+        attachKeyAttestation: Boolean,
+        keyAttestationJwt: String?
     ): WrappedCredentialResponse? {
-        val TAG = "processCredentialRequestLijoTest"
+        val TAG = "processCredentialRequestKeyAttestation"
 
         val dpopHeaderValue =
             if (!issuerConfig?.credentialEndpoint.isNullOrEmpty()
@@ -944,7 +918,12 @@ class IssueService : IssueServiceInterface {
         }
 
         val credentialEncryptionBuilder = CredentialEncryptionBuilder()
-        val jwt = ProofService().createProof(did, subJwk, nonce , issuerConfig,credentialOffer,index)
+        // ARF TS3 v1.5: the KA travels in the proof's key_attestation header,
+        // bound to the same c_nonce as the proof.
+        val keyAttestation = KeyAttestationService.forProof(
+            keyAttestationJwt, attachKeyAttestation, subJwk, nonce
+        )
+        val jwt = ProofService().createProof(did, subJwk, nonce , issuerConfig,credentialOffer,index, keyAttestation)
         if (jwt == null) {
             Log.e("IssueService", "Failed to create proof for credential request")
             return null

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
@@ -298,22 +298,27 @@ class IssueService : IssueServiceInterface {
 
         // ---------- PAR Request ----------
         else if (authConfig?.requirePushedAuthorizationRequests == true) {
+            val parParams = mapOf(
+                "response_type" to responseType,
+                "scope" to scope.trim(),
+                "state" to state,
+                "client_id" to (clientId ?: ""),
+                "authorization_details" to authorisationDetails,
+                "redirect_uri" to redirectURI,
+                "nonce" to nonce,
+                "code_challenge" to (codeChallenge ?: ""),
+                "code_challenge_method" to codeChallengeMethod,
+                "client_metadata" to clientMetadata,
+                "issuer_state" to (credentialOffer?.grants?.authorizationCode?.issuerState ?: "")
+            )
+            headers.forEach { (k, v) ->
+                v.chunked(3000).forEachIndexed { i, chunk ->
+                }
+            }
             val result = SafeApiCall.safeApiCallResponse {
                 ApiManager.api.getService()?.processParAuthorisationRequest(
                     authConfig.pushedAuthorizationRequestEndpoint ?: "",
-                    mapOf(
-                        "response_type" to responseType,
-                        "scope" to scope.trim(),
-                        "state" to state,
-                        "client_id" to (clientId ?: ""),
-                        "authorization_details" to authorisationDetails,
-                        "redirect_uri" to redirectURI,
-                        "nonce" to nonce,
-                        "code_challenge" to (codeChallenge ?: ""),
-                        "code_challenge_method" to codeChallengeMethod,
-                        "client_metadata" to clientMetadata,
-                        "issuer_state" to (credentialOffer?.grants?.authorizationCode?.issuerState ?: "")
-                    ),
+                    parParams,
                     headers
                 )
             }
@@ -941,7 +946,12 @@ class IssueService : IssueServiceInterface {
                 credentialConfigurationId = authorizationDetail.credentialConfigurationId,
                 proof = ProofV3(jwt =  jwt, proofType = "jwt"),
             )
-        } else if (accessToken?.cNonce==null && issuerConfig?.nonceEndpoint!=null && accessToken?.authorizationDetails.isNullOrEmpty()){
+        } else if (issuerConfig?.nonceEndpoint!=null && accessToken?.authorizationDetails.isNullOrEmpty()){
+            // OpenID4VCI 1.0 (issuer publishes a nonce endpoint): the request
+            // carries credential_configuration_id, never format+vct. The old
+            // extra gate on cNonce==null dropped issuers that return a c_nonce
+            // in the token response AS WELL (BankID), and they rejected the
+            // legacy format+vct body with "Invalid request format".
             Log.d(TAG,"entered third condition")
             CredentialRequest(
                 credentialConfigurationId = credentialOffer?.credentials?.get(index)?.types?.firstOrNull(),
@@ -979,6 +989,9 @@ class IssueService : IssueServiceInterface {
         }
 
         request.credentialResponseEncryption = credentialEncryptionBuilder.build(ecKeyWithAlgEnc)
+
+        Gson().toJson(request).chunked(3000).forEachIndexed { i, chunk ->
+        }
 
         // Safely perform network call using SafeApiCall
         val result = SafeApiCall.safeApiCallResponse {

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
@@ -1337,9 +1337,28 @@ class IssueService : IssueServiceInterface {
         accessToken: String?,
         deferredCredentialEndPoint: String?,
         ecKeyWithAlgEnc: ECKeyWithAlgEnc?,
-        credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?
+        credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
+        dpopKey: ECKey?
     ): WrappedCredentialResponse? {
         val credentialEncryptionBuilder = CredentialEncryptionBuilder()
+        // A DPoP-bound access token must stay DPoP-bound on the deferred
+        // endpoint too: same key as the token request, fresh jti, ath.
+        val dpopHeaderValue =
+            if (dpopKey != null && !deferredCredentialEndPoint.isNullOrEmpty() && accessToken != null) {
+                DPoPProofService().generateDPoP(
+                    httpMethod = "POST",
+                    targetUri = deferredCredentialEndPoint,
+                    dpopKey = dpopKey,
+                    claims = mapOf(
+                        "ath" to DPoPProofService().computeAccessTokenHash(accessToken)
+                    )
+                )
+            } else null
+        val authHeaderValue = if (dpopHeaderValue != null) {
+            "DPoP $accessToken"
+        } else {
+            "Bearer $accessToken"
+        }
         return try {
             val result = SafeApiCall.safeApiCallResponse {
                 if (credentialRequestEncryptionInfo?.encryptionRequired == true) {
@@ -1358,8 +1377,9 @@ class IssueService : IssueServiceInterface {
                         ApiManager.api.getService()?.getDifferedCredentialV2Encrypted(
                             deferredCredentialEndPoint ?: "",
                             "application/jwt",
-                            "Bearer $accessToken",
-                            requestBody
+                            authHeaderValue,
+                            requestBody,
+                            dpop = dpopHeaderValue
                         )
                     } else {
                         null
@@ -1367,8 +1387,9 @@ class IssueService : IssueServiceInterface {
                 } else {
                     ApiManager.api.getService()?.getDifferedCredentialV2(
                         deferredCredentialEndPoint ?: "",
-                        "Bearer $accessToken",
-                        DeferredCredentialRequestV2(transactionId)
+                        authHeaderValue,
+                        DeferredCredentialRequestV2(transactionId),
+                        dpop = dpopHeaderValue
                     )
                 }
             }

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueServiceInterface.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueServiceInterface.kt
@@ -119,7 +119,9 @@ interface IssueServiceInterface {
         ecKeyWithAlgEnc:ECKeyWithAlgEnc? =null,
         credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
         authConfig: AuthorisationServerWellKnownConfiguration?,
-        dpopKey: ECKey?
+        dpopKey: ECKey?,
+        attachKeyAttestation: Boolean = false,
+        keyAttestationJwt: String? = null
     ): WrappedCredentialResponse?
 
     /**

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueServiceInterface.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueServiceInterface.kt
@@ -142,7 +142,8 @@ interface IssueServiceInterface {
         accessToken: String?,
         deferredCredentialEndPoint: String?,
         ecKeyWithAlgEnc: ECKeyWithAlgEnc? = null,
-        credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?
+        credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
+        dpopKey: ECKey? = null
     ): WrappedCredentialResponse?
 
     /**

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiServices.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiServices.kt
@@ -5,6 +5,8 @@ import com.ewc.eudi_wallet_oidc_android.InteractiveAuthResponse
 import com.ewc.eudi_wallet_oidc_android.models.RefreshTokenResponse
 import com.ewc.eudi_wallet_oidc_android.models.AuthorisationServerWellKnownConfiguration
 import com.ewc.eudi_wallet_oidc_android.models.ClientAssertion
+import com.ewc.eudi_wallet_oidc_android.models.KeyAttestationRequest
+import com.ewc.eudi_wallet_oidc_android.models.KeyAttestationResponse
 import com.ewc.eudi_wallet_oidc_android.models.CredentialRequest
 import com.ewc.eudi_wallet_oidc_android.models.CredentialResponse
 import com.ewc.eudi_wallet_oidc_android.models.DIDDocument
@@ -160,6 +162,13 @@ interface ApiService {
 
     @GET
     suspend fun fetchNonce(@Url url: String): Response<ResponseBody>
+
+    @POST
+    suspend fun sendKeyAttestationRequest(
+        @Url url: String,
+        @HeaderMap headers: Map<String, String>,
+        @Body body: KeyAttestationRequest
+    ): Response<KeyAttestationResponse>
 
     @FormUrlEncoded
     @POST("")

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiServices.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/network/ApiServices.kt
@@ -118,7 +118,8 @@ interface ApiService {
     suspend fun getDifferedCredentialV2(
         @Url url: String,
         @Header("Authorization") authorization: String,
-        @Body body: DeferredCredentialRequestV2
+        @Body body: DeferredCredentialRequestV2,
+        @Header("DPoP") dpop: String? = null
     ): Response<ResponseBody>
 
     @POST("")
@@ -126,7 +127,8 @@ interface ApiService {
         @Url url: String,
         @Header("content-type") contentType: String,
         @Header("Authorization") authorization: String,
-        @Body body: RequestBody
+        @Body body: RequestBody,
+        @Header("DPoP") dpop: String? = null
     ): Response<ResponseBody>
 
     @GET

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/nonceRequest/NonceService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/nonceRequest/NonceService.kt
@@ -10,10 +10,12 @@ class NonceService : NonceServiceInterface {
     override suspend fun fetchNonce(accessToken: String?, nonceEndPoint: String?): String? {
         if (nonceEndPoint.isNullOrBlank()) return null
 
-        val authorizationHeader = accessToken?.takeIf { it.isNotBlank() }?.let { "Bearer $it" }
-
+        // OpenID4VCI 1.0 (§ Nonce Endpoint): the nonce request is
+        // UNAUTHENTICATED. Sending an Authorization header (a Bearer copy of a
+        // DPoP-bound token, at that) makes strict issuers answer 401 with an
+        // empty body, and the whole flow loses its c_nonce.
         val result = SafeApiCall.safeApiCallResponse {
-            ApiManager.api.getService()?.fetchNonce(nonceEndPoint, authorizationHeader)
+            ApiManager.api.getService()?.fetchNonce(nonceEndPoint, null)
         }
 
         var nonce: String? = null

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceService.kt
@@ -19,6 +19,7 @@ import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall
 import com.ewc.eudi_wallet_oidc_android.services.utils.DPoPProofService
 import com.ewc.eudi_wallet_oidc_android.services.utils.ErrorHandler
 import com.ewc.eudi_wallet_oidc_android.services.utils.ProofService
+import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.KeyAttestationService
 import com.ewc.eudi_wallet_oidc_android.services.verification.authorisationResponse.JWEEncrypter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -40,7 +41,8 @@ class ReIssuanceService : ReIssuanceServiceInterface {
         ecKeyWithAlgEnc: ECKeyWithAlgEnc?,
         credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
         interactiveAuthorizationEndpoint: String?,
-        dpopKey: ECKey?
+        dpopKey: ECKey?,
+        attachKeyAttestation: Boolean
     ): WrappedCredentialResponse? {
         val dpopHeaderValue =
             if (!issuerConfig?.credentialEndpoint.isNullOrEmpty() &&
@@ -68,7 +70,12 @@ class ReIssuanceService : ReIssuanceServiceInterface {
         }
 
         val credentialEncryptionBuilder = CredentialEncryptionBuilder()
-        val jwt = ProofService().createProof(did, subJwk, nonce, issuerConfig, credentialOffer, index)
+        // ARF TS3 v1.5: the KA travels in the proof's key_attestation header,
+        // bound to the same c_nonce as the proof.
+        val keyAttestation = KeyAttestationService.forProof(
+            null, attachKeyAttestation, subJwk, nonce
+        )
+        val jwt = ProofService().createProof(did, subJwk, nonce, issuerConfig, credentialOffer, index, keyAttestation)
         if (jwt == null) {
             Log.e("IssueService", "Failed to create proof for credential request")
             return null

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceService.kt
@@ -42,7 +42,8 @@ class ReIssuanceService : ReIssuanceServiceInterface {
         credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
         interactiveAuthorizationEndpoint: String?,
         dpopKey: ECKey?,
-        attachKeyAttestation: Boolean
+        attachKeyAttestation: Boolean,
+        keyAttestationJwt: String?
     ): WrappedCredentialResponse? {
         val dpopHeaderValue =
             if (!issuerConfig?.credentialEndpoint.isNullOrEmpty() &&
@@ -70,10 +71,10 @@ class ReIssuanceService : ReIssuanceServiceInterface {
         }
 
         val credentialEncryptionBuilder = CredentialEncryptionBuilder()
-        // ARF TS3 v1.5: the KA travels in the proof's key_attestation header,
-        // bound to the same c_nonce as the proof.
+        // ARF TS3 v1.5: the wallet-provider-issued KA travels in the proof's
+        // key_attestation header, bound to the same c_nonce as the proof.
         val keyAttestation = KeyAttestationService.forProof(
-            null, attachKeyAttestation, subJwk, nonce
+            keyAttestationJwt, attachKeyAttestation
         )
         val jwt = ProofService().createProof(did, subJwk, nonce, issuerConfig, credentialOffer, index, keyAttestation)
         if (jwt == null) {

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceServiceInterface.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceServiceInterface.kt
@@ -24,7 +24,8 @@ interface ReIssuanceServiceInterface {
         credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
         interactiveAuthorizationEndpoint: String?,
         dpopKey: ECKey?,
-        attachKeyAttestation: Boolean = false
+        attachKeyAttestation: Boolean = false,
+        keyAttestationJwt: String? = null
     ): WrappedCredentialResponse?
 
 }

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceServiceInterface.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/reissuance/ReIssuanceServiceInterface.kt
@@ -23,7 +23,8 @@ interface ReIssuanceServiceInterface {
         ecKeyWithAlgEnc:ECKeyWithAlgEnc?,
         credentialRequestEncryptionInfo: CredentialRequestEncryptionInfo?,
         interactiveAuthorizationEndpoint: String?,
-        dpopKey: ECKey?
+        dpopKey: ECKey?,
+        attachKeyAttestation: Boolean = false
     ): WrappedCredentialResponse?
 
 }

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustMechanismService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/trust/TrustMechanismService.kt
@@ -9,7 +9,7 @@ import com.ewc.eudi_wallet_oidc_android.models.TSPServices
 import com.ewc.eudi_wallet_oidc_android.models.TrustServiceProvider
 import com.ewc.eudi_wallet_oidc_android.services.network.ApiManager
 import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall.safeApiCallResponse
-import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.WalletAttestationUtil.TAG
+import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.WalletUnitAttestationService.TAG
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/ProofService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/ProofService.kt
@@ -25,7 +25,8 @@ class ProofService {
         nonce: String?,
         issuerConfig: IssuerWellKnownConfiguration?,
         credentialOffer: CredentialOffer?,
-        index: Int = 0
+        index: Int = 0,
+        keyAttestation: String? = null
     ): String? {
         val credentialsSupported = issuerConfig?.credentialsSupported
         val credentials = credentialOffer?.credentials
@@ -66,6 +67,12 @@ class ProofService {
         }
         else {
             jwsHeaderBuilder.jwk(subJwk?.toPublicJWK())
+        }
+
+        // ARF TS3 v1.5: the Key Attestation travels in the key_attestation
+        // JOSE header of the jwt proof.
+        if (!keyAttestation.isNullOrEmpty()) {
+            jwsHeaderBuilder.customParam("key_attestation", keyAttestation)
         }
 
         val jwsHeader = jwsHeaderBuilder.build()

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/KeyAttestationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/KeyAttestationService.kt
@@ -21,17 +21,21 @@ import java.util.Date
 /**
  * ARF TS3 v1.5 Key Attestation (KA).
  *
- * The main flow mints the KA on-device: the KA carries the same c_nonce as the
- * credential-request proof, so it works with any issuer and needs no
- * wallet-provider round-trip. The wallet-provider endpoint is exposed as a thin
- * optional API — its KA is only usable when the credential issuer IS the
- * wallet-provider organisation, because the KA nonce must match the proof
- * nonce and the provider validates the nonce against its own 60-second store.
+ * TS3 §2.2.2.1: the KA SHALL be generated and signed by the Wallet Provider —
+ * the wallet never mints a KA itself. [requestKeyAttestation] sends the key
+ * evidence (Android Keystore chain for the hardware tier, key PoPs for the
+ * software tier) to the wallet-provider backend, which verifies it and signs
+ * the KA. The nonce is the ISSUER's c_nonce for the credential request
+ * (TS3 §2.2.2): the wallet passes it to the wallet provider, the evidence is
+ * bound to it, and the issuer — not the wallet provider — validates its
+ * freshness against its own nonce endpoint.
  */
 object KeyAttestationService {
     const val TAG = "KeyAttestation"
 
-    private const val KA_TYP = "key-attestation+jwt"
+    /** Shared watch tag for the KA path. Filter with: adb logcat -s KaWatch */
+    private const val KA_WATCH = "KaWatch"
+
     private const val KEY_POP_TYP = "key-pop+jwt"
 
     /**
@@ -68,87 +72,34 @@ object KeyAttestationService {
     ): Boolean = getRequirement(issuerConfig, type) != null
 
     /**
-     * The KA that goes on a credential-request proof: a pre-minted (hardware)
-     * KA wins; otherwise the software tier is minted here with the SAME
-     * c_nonce as the proof. Null when no KA is wanted or possible.
+     * The KA that goes on a credential-request proof. Only a wallet-provider
+     * issued KA is accepted (TS3 §2.2.2.1) — there is no on-device fallback.
+     * Null when no KA is wanted, or when one was wanted but the wallet
+     * provider did not deliver it (the issuer then rejects or warns).
      */
     fun forProof(
-        preMinted: String?,
-        attach: Boolean,
-        bindingKey: JWK?,
-        cNonce: String?
+        walletProviderKa: String?,
+        attach: Boolean
     ): String? {
-        return preMinted
-            ?: if (attach && bindingKey is ECKey) {
-                mintSoftwareKeyAttestation(bindingKey, cNonce)
-            } else null
-    }
-
-    /**
-     * Software tier ("software_self_attested"): the KA is self-signed by the
-     * binding key. The server forces the software assurance labels; this tier
-     * does not satisfy an iso_18045_high (enforceWUA) requirement.
-     */
-    fun mintSoftwareKeyAttestation(
-        bindingKey: ECKey,
-        cNonce: String?
-    ): String? {
-        return try {
-            val now = Date()
-            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
-                .type(JOSEObjectType(KA_TYP))
-                .build()
-            val claims = JWTClaimsSet.Builder()
-                .issueTime(now)
-                .expirationTime(Date(now.time + 12 * 60 * 60 * 1000))
-                .claim("attested_keys", listOf(bindingKey.toPublicJWK().toJSONObject()))
-                .apply { if (!cNonce.isNullOrEmpty()) claim("nonce", cNonce) }
-                .build()
-            val jwt = SignedJWT(header, claims)
-            jwt.sign(ECDSASigner(bindingKey))
-            jwt.serialize()
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to mint software key attestation: ${e.message}")
-            null
+        if (walletProviderKa != null) {
+            Log.d(KA_WATCH, "proof KA source: wallet-provider issued")
+            return walletProviderKa
         }
-    }
-
-    /**
-     * Hardware tier ("android_keystore"): the KA is signed by the Android
-     * Keystore binding key and carries the Google-rooted attestation chain in
-     * x5c. The KeyDescription challenge in the leaf certificate must be the
-     * c_nonce, so the key must be generated with that challenge.
-     */
-    fun mintHardwareKeyAttestation(
-        signableKey: ECKey,
-        x5cBase64: List<String>,
-        cNonce: String?
-    ): String? {
-        return try {
-            val now = Date()
-            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
-                .type(JOSEObjectType(KA_TYP))
-                .x509CertChain(x5cBase64.map { com.nimbusds.jose.util.Base64(it) })
-                .build()
-            val claims = JWTClaimsSet.Builder()
-                .issueTime(now)
-                .expirationTime(Date(now.time + 12 * 60 * 60 * 1000))
-                .claim("attested_keys", listOf(signableKey.toPublicJWK().toJSONObject()))
-                .apply { if (!cNonce.isNullOrEmpty()) claim("nonce", cNonce) }
-                .build()
-            val jwt = SignedJWT(header, claims)
-            jwt.sign(ECDSASigner(signableKey))
-            jwt.serialize()
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to mint hardware key attestation: ${e.message}")
-            null
+        if (attach) {
+            Log.e(
+                KA_WATCH,
+                "KA wanted but the wallet provider did not deliver one — " +
+                    "proof goes WITHOUT a KA (TS3: the wallet never self-mints)"
+            )
         }
+        return null
     }
 
     /**
-     * Proof of possession over the wallet-provider nonce, for the optional
-     * wallet-provider endpoint. The key_pops array is positionally aligned
-     * with attested_keys; the WIA cnf key's slot needs a placeholder.
+     * Proof of possession over the issuer c_nonce, for the wallet-provider
+     * key-attestation endpoint (software tier). The key_pops array is
+     * positionally aligned with attested_keys; the WIA cnf key's slot needs
+     * a placeholder.
      */
     fun generateKeyProofOfPossession(key: ECKey, nonce: String): String? {
         return try {
@@ -169,35 +120,11 @@ object KeyAttestationService {
     }
 
     /**
-     * Single-use server nonce for the wallet-provider key-attestation
-     * endpoint (GET .../wallet-provider/nonce). The Keystore key must be
-     * generated with THIS nonce as the attestation challenge, and the
-     * key PoPs must sign it.
-     */
-    suspend fun fetchKeyAttestationNonce(baseUrl: String): String? = withContext(Dispatchers.IO) {
-        val result = SafeApiCall.safeApiCallResponse {
-            ApiManager.api.getService()?.fetchNonce(url = "$baseUrl/wallet-provider/nonce")
-        }
-        result.onSuccess { response ->
-            if (response.isSuccessful) {
-                response.body()?.string()?.let {
-                    return@withContext com.google.gson.Gson()
-                        .fromJson(it, com.ewc.eudi_wallet_oidc_android.NonceResponse::class.java)
-                        .nonce
-                }
-            } else {
-                Log.e(TAG, "Failed to fetch key attestation nonce: ${response.errorBody()?.string()}")
-            }
-        }.onFailure { e ->
-            Log.e(TAG, "Error fetching key attestation nonce: ${e.message}")
-        }
-        return@withContext null
-    }
-
-    /**
-     * Optional: request a wallet-provider-signed KA. Only usable when the
-     * credential issuer is the wallet-provider organisation (see class KDoc).
-     * The wallet unit must be authorised on the wallet provider.
+     * Request the KA from the wallet provider (TS3 §2.2.2.1). The nonce is
+     * the ISSUER's c_nonce for the credential request: the Keystore key must
+     * be generated with it as the attestation challenge (hardware tier), or
+     * the key PoPs must sign it (software tier). The wallet unit must be
+     * registered and authorised on the wallet provider.
      */
     suspend fun requestKeyAttestation(
         baseUrl: String,
@@ -220,6 +147,16 @@ object KeyAttestationService {
             androidKeyAttestationX5c = androidKeyAttestationX5c,
             keyPops = keyPops
         )
+        Log.d(
+            KA_WATCH,
+            "POST $baseUrl/wallet-provider/key-attestation " +
+                "keys=${attestedKeys.size} " +
+                "evidence=${
+                    if (androidKeyAttestationX5c != null)
+                        "android_x5c(${androidKeyAttestationX5c.size} certs)"
+                    else "key_pops(${keyPops?.size ?: 0})"
+                } nonce=$nonce"
+        )
         val result = SafeApiCall.safeApiCallResponse {
             ApiManager.api.getService()?.sendKeyAttestationRequest(
                 url = "$baseUrl/wallet-provider/key-attestation",
@@ -229,13 +166,22 @@ object KeyAttestationService {
         }
         result.onSuccess { response ->
             if (response.isSuccessful) {
-                return@withContext response.body()
+                val ka = response.body()
+                Log.d(
+                    KA_WATCH,
+                    "WP KA response ${response.code()}: " +
+                        "attestationType=${ka?.attestationType} keyStorage=${ka?.keyStorage}"
+                )
+                return@withContext ka
             } else {
-                Log.e(TAG, "Key attestation request failed: ${response.errorBody()?.string()}")
+                val error = response.errorBody()?.string()
+                Log.e(TAG, "Key attestation request failed: $error")
+                Log.e(KA_WATCH, "WP KA response ${response.code()}: $error")
                 return@withContext null
             }
         }.onFailure { e ->
             Log.e(TAG, "Error sending key attestation request: ${e.message}")
+            Log.e(KA_WATCH, "WP KA transport error: ${e.message}")
             return@withContext null
         }
         return@withContext null

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/KeyAttestationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/KeyAttestationService.kt
@@ -1,0 +1,217 @@
+package com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation
+
+import android.util.Log
+import com.ewc.eudi_wallet_oidc_android.models.IssuerWellKnownConfiguration
+import com.ewc.eudi_wallet_oidc_android.models.KeyAttestationRequest
+import com.ewc.eudi_wallet_oidc_android.models.KeyAttestationResponse
+import com.ewc.eudi_wallet_oidc_android.services.network.ApiManager
+import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.Date
+
+/**
+ * ARF TS3 v1.5 Key Attestation (KA).
+ *
+ * The main flow mints the KA on-device: the KA carries the same c_nonce as the
+ * credential-request proof, so it works with any issuer and needs no
+ * wallet-provider round-trip. The wallet-provider endpoint is exposed as a thin
+ * optional API — its KA is only usable when the credential issuer IS the
+ * wallet-provider organisation, because the KA nonce must match the proof
+ * nonce and the provider validates the nonce against its own 60-second store.
+ */
+object KeyAttestationService {
+    const val TAG = "KeyAttestation"
+
+    private const val KA_TYP = "key-attestation+jwt"
+    private const val KEY_POP_TYP = "key-pop+jwt"
+
+    /**
+     * Reads proof_types_supported.jwt.key_attestations_required for the
+     * credential configuration matching the given type, from the raw issuer
+     * metadata. Null when the issuer does not require a key attestation.
+     */
+    fun getRequirement(
+        issuerConfig: IssuerWellKnownConfiguration?,
+        type: String?
+    ): Map<String, Any>? {
+        if (issuerConfig == null || type.isNullOrEmpty()) return null
+        return try {
+            val credentialsSupported = issuerConfig.credentialsSupported ?: return null
+            val matching: Map<*, *>? = when (credentialsSupported) {
+                is Map<*, *> -> credentialsSupported[type] as? Map<*, *>
+                is List<*> -> credentialsSupported.filterIsInstance<Map<*, *>>()
+                    .find { (it["id"] as? String)?.contains(type) == true }
+                else -> null
+            }
+            val proofTypes = matching?.get("proof_types_supported") as? Map<*, *> ?: return null
+            val jwtProof = proofTypes["jwt"] as? Map<*, *> ?: return null
+            @Suppress("UNCHECKED_CAST")
+            jwtProof["key_attestations_required"] as? Map<String, Any>
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read key_attestations_required: ${e.message}")
+            null
+        }
+    }
+
+    fun isRequired(
+        issuerConfig: IssuerWellKnownConfiguration?,
+        type: String?
+    ): Boolean = getRequirement(issuerConfig, type) != null
+
+    /**
+     * The KA that goes on a credential-request proof: a pre-minted (hardware)
+     * KA wins; otherwise the software tier is minted here with the SAME
+     * c_nonce as the proof. Null when no KA is wanted or possible.
+     */
+    fun forProof(
+        preMinted: String?,
+        attach: Boolean,
+        bindingKey: JWK?,
+        cNonce: String?
+    ): String? {
+        return preMinted
+            ?: if (attach && bindingKey is ECKey) {
+                mintSoftwareKeyAttestation(bindingKey, cNonce)
+            } else null
+    }
+
+    /**
+     * Software tier ("software_self_attested"): the KA is self-signed by the
+     * binding key. The server forces the software assurance labels; this tier
+     * does not satisfy an iso_18045_high (enforceWUA) requirement.
+     */
+    fun mintSoftwareKeyAttestation(
+        bindingKey: ECKey,
+        cNonce: String?
+    ): String? {
+        return try {
+            val now = Date()
+            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(JOSEObjectType(KA_TYP))
+                .build()
+            val claims = JWTClaimsSet.Builder()
+                .issueTime(now)
+                .expirationTime(Date(now.time + 12 * 60 * 60 * 1000))
+                .claim("attested_keys", listOf(bindingKey.toPublicJWK().toJSONObject()))
+                .apply { if (!cNonce.isNullOrEmpty()) claim("nonce", cNonce) }
+                .build()
+            val jwt = SignedJWT(header, claims)
+            jwt.sign(ECDSASigner(bindingKey))
+            jwt.serialize()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to mint software key attestation: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Hardware tier ("android_keystore"): the KA is signed by the Android
+     * Keystore binding key and carries the Google-rooted attestation chain in
+     * x5c. The KeyDescription challenge in the leaf certificate must be the
+     * c_nonce, so the key must be generated with that challenge.
+     */
+    fun mintHardwareKeyAttestation(
+        signableKey: ECKey,
+        x5cBase64: List<String>,
+        cNonce: String?
+    ): String? {
+        return try {
+            val now = Date()
+            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(JOSEObjectType(KA_TYP))
+                .x509CertChain(x5cBase64.map { com.nimbusds.jose.util.Base64(it) })
+                .build()
+            val claims = JWTClaimsSet.Builder()
+                .issueTime(now)
+                .expirationTime(Date(now.time + 12 * 60 * 60 * 1000))
+                .claim("attested_keys", listOf(signableKey.toPublicJWK().toJSONObject()))
+                .apply { if (!cNonce.isNullOrEmpty()) claim("nonce", cNonce) }
+                .build()
+            val jwt = SignedJWT(header, claims)
+            jwt.sign(ECDSASigner(signableKey))
+            jwt.serialize()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to mint hardware key attestation: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Proof of possession over the wallet-provider nonce, for the optional
+     * wallet-provider endpoint. The key_pops array is positionally aligned
+     * with attested_keys; the WIA cnf key's slot needs a placeholder.
+     */
+    fun generateKeyProofOfPossession(key: ECKey, nonce: String): String? {
+        return try {
+            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(JOSEObjectType(KEY_POP_TYP))
+                .build()
+            val claims = JWTClaimsSet.Builder()
+                .issueTime(Date())
+                .claim("nonce", nonce)
+                .build()
+            val jwt = SignedJWT(header, claims)
+            jwt.sign(ECDSASigner(key))
+            jwt.serialize()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create key proof of possession: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Optional: request a wallet-provider-signed KA. Only usable when the
+     * credential issuer is the wallet-provider organisation (see class KDoc).
+     * The wallet unit must be authorised on the wallet provider.
+     */
+    suspend fun requestKeyAttestation(
+        baseUrl: String,
+        walletUnitAttestationJWT: String,
+        walletUnitProofOfPossession: String,
+        nonce: String,
+        attestedKeys: List<JWK>,
+        keyPops: List<String>? = null,
+        androidKeyAttestationX5c: List<String>? = null
+    ): KeyAttestationResponse? = withContext(Dispatchers.IO) {
+        val headers = WalletUnitAttestationHeaders.build(
+            walletUnitAttestationJWT,
+            walletUnitProofOfPossession
+        ).apply {
+            this["X-Wallet-Unit-Nonce"] = nonce
+            this["X-Wallet-Unit-Platform"] = "android"
+        }
+        val body = KeyAttestationRequest(
+            attestedKeys = attestedKeys.map { it.toPublicJWK().toJSONObject() },
+            androidKeyAttestationX5c = androidKeyAttestationX5c,
+            keyPops = keyPops
+        )
+        val result = SafeApiCall.safeApiCallResponse {
+            ApiManager.api.getService()?.sendKeyAttestationRequest(
+                url = "$baseUrl/wallet-provider/key-attestation",
+                headers = headers,
+                body = body
+            )
+        }
+        result.onSuccess { response ->
+            if (response.isSuccessful) {
+                return@withContext response.body()
+            } else {
+                Log.e(TAG, "Key attestation request failed: ${response.errorBody()?.string()}")
+                return@withContext null
+            }
+        }.onFailure { e ->
+            Log.e(TAG, "Error sending key attestation request: ${e.message}")
+            return@withContext null
+        }
+        return@withContext null
+    }
+}

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/KeyAttestationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/KeyAttestationService.kt
@@ -169,6 +169,32 @@ object KeyAttestationService {
     }
 
     /**
+     * Single-use server nonce for the wallet-provider key-attestation
+     * endpoint (GET .../wallet-provider/nonce). The Keystore key must be
+     * generated with THIS nonce as the attestation challenge, and the
+     * key PoPs must sign it.
+     */
+    suspend fun fetchKeyAttestationNonce(baseUrl: String): String? = withContext(Dispatchers.IO) {
+        val result = SafeApiCall.safeApiCallResponse {
+            ApiManager.api.getService()?.fetchNonce(url = "$baseUrl/wallet-provider/nonce")
+        }
+        result.onSuccess { response ->
+            if (response.isSuccessful) {
+                response.body()?.string()?.let {
+                    return@withContext com.google.gson.Gson()
+                        .fromJson(it, com.ewc.eudi_wallet_oidc_android.NonceResponse::class.java)
+                        .nonce
+                }
+            } else {
+                Log.e(TAG, "Failed to fetch key attestation nonce: ${response.errorBody()?.string()}")
+            }
+        }.onFailure { e ->
+            Log.e(TAG, "Error fetching key attestation nonce: ${e.message}")
+        }
+        return@withContext null
+    }
+
+    /**
      * Optional: request a wallet-provider-signed KA. Only usable when the
      * credential issuer is the wallet-provider organisation (see class KDoc).
      * The wallet unit must be authorised on the wallet provider.

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationHeaders.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationHeaders.kt
@@ -1,0 +1,55 @@
+package com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation
+
+import android.util.Base64
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+
+/**
+ * Single home for attaching a Wallet Unit Attestation (WUA) to outgoing requests:
+ * the OAuth-Client-Attestation / OAuth-Client-Attestation-PoP header pair and the
+ * client_id rule (sub claim of the WUA JWT, fallback to the DID).
+ */
+object WalletUnitAttestationHeaders {
+    const val CLIENT_ATTESTATION = "OAuth-Client-Attestation"
+    const val CLIENT_ATTESTATION_POP = "OAuth-Client-Attestation-PoP"
+
+    /** Builds the WUA header pair. Strips one trailing "~" from the JWT. Skips null/empty values. */
+    fun build(
+        walletUnitAttestationJWT: String?,
+        walletUnitProofOfPossession: String?
+    ): MutableMap<String, String> {
+        return mutableMapOf<String, String>().apply {
+            if (!walletUnitAttestationJWT.isNullOrEmpty()) {
+                this[CLIENT_ATTESTATION] = walletUnitAttestationJWT.removeSuffix("~")
+            }
+            if (!walletUnitProofOfPossession.isNullOrEmpty()) {
+                this[CLIENT_ATTESTATION_POP] = walletUnitProofOfPossession
+            }
+        }
+    }
+
+    /** client_id rule: sub claim of the WUA JWT, fallback to the DID. */
+    fun clientId(walletUnitAttestationJWT: String?, fallbackDid: String?): String? {
+        return extractSub(walletUnitAttestationJWT) ?: fallbackDid
+    }
+
+    private fun extractSub(jwt: String?): String? {
+        try {
+            if (jwt.isNullOrEmpty()) return null
+
+            val parts = jwt.split(".")
+            if (parts.size < 2) return null
+
+            val payload = parts[1]
+            // Base64 decode payload (URL-safe, no padding)
+            val decodedBytes = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+            val payloadJson = String(decodedBytes, Charsets.UTF_8)
+
+            // Parse JSON
+            val jsonObject = Gson().fromJson(payloadJson, JsonObject::class.java)
+            return jsonObject.get("sub")?.asString
+        } catch (e: Exception) {
+            return null
+        }
+    }
+}

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationService.kt
@@ -1,0 +1,323 @@
+package com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation
+
+
+import android.content.Context
+import android.util.Log
+import com.ewc.eudi_wallet_oidc_android.CredentialOfferResponse
+import com.ewc.eudi_wallet_oidc_android.NonceResponse
+import com.ewc.eudi_wallet_oidc_android.WalletAttestationResult
+import com.ewc.eudi_wallet_oidc_android.models.ClientAssertion
+import com.ewc.eudi_wallet_oidc_android.services.did.DIDService
+import com.ewc.eudi_wallet_oidc_android.services.network.ApiManager
+import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall
+import com.ewc.eudi_wallet_oidc_android.services.utils.generateHash
+import com.google.android.play.core.integrity.IntegrityManagerFactory
+import com.google.android.play.core.integrity.StandardIntegrityManager
+import com.google.gson.Gson
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.util.Date
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Single home for the Wallet Unit Attestation (WUA) registration flow:
+ * key generation, DID creation, Play Integrity, nonce fetch, client assertion,
+ * the wallet-unit registration request, and the WUA proof-of-possession JWT.
+ */
+object WalletUnitAttestationService {
+    const val TAG = "WalletUnitAttestation"
+
+
+    suspend fun initiateWalletUnitAttestation(
+        context: Context,
+        cloudProjectNumber: Long,
+        baseUrl: String,
+        inputEcKey: ECKey? = null,
+        profile: String? = null
+    ): WalletAttestationResult? {
+        var clientAssertion: String? = null
+        return try {
+            // Step 1: Generate the key pair with attestation
+            val ecKey = inputEcKey ?: run {
+                val keyPair = generateES256Key()
+                val publicKey = keyPair?.public?.let { DIDService().convertToECPublicKey(it) }
+                val privateKey = keyPair?.private?.let { DIDService().convertToECPrivateKey(it) }
+                Log.d(TAG, "Generated privateKey with attestation: $privateKey")
+                Log.d(TAG, "Generated publicKey with attestation: $publicKey")
+
+                ECKey.Builder(Curve.P_256, publicKey).privateKey(privateKey).build()
+            }
+            val did = DIDService().createDID(ecKey)
+            Log.d(TAG, "Generated DID: $did")
+            // Step 2: Prepare the integrity token provider
+            val tokenProvider = prepareIntegrityTokenProvider(context, cloudProjectNumber)
+            Log.d(TAG, "Prepare tokenProvider: $tokenProvider")
+
+            // Step 3: Fetch the nonce from the server
+            val nonce = fetchNonceForDeviceIntegrityToken("$baseUrl/nonce")
+            Log.d(TAG, "Fetched nonce: $nonce")
+
+            // Step 4: Generate a request hash from the nonce
+
+            val requestHash = nonce?.let { generateHash(it) }
+            Log.d(TAG, "Generated request hash: $requestHash")
+
+            // Step 5: Request an integrity token
+            val token = requestIntegrityToken(tokenProvider, requestHash)
+            Log.d(TAG, "integrity token:$token ")
+
+            // Step 6: Generate client assertion
+            clientAssertion = generateClientAssertion(ecKey, did, audience = baseUrl)
+            Log.d(TAG, "clientAssertion:$clientAssertion ")
+
+
+            // Step 7: Process the wallet unit attestation request
+            val walletUnitAttestationCredential =
+                processWalletUnitAttestationRequest(baseUrl, token, nonce, clientAssertion, profile)
+
+
+            // Step 8: Log and return both values
+            if (walletUnitAttestationCredential != null) {
+                Log.d("WalletUnitAttestationCredential", walletUnitAttestationCredential.toString())
+            }
+
+            WalletAttestationResult(
+                walletUnitAttestationCredential?.credentialOffer,
+                walletUnitAttestationCredential?.walletUnitAttestation,
+                clientAssertion,
+                did,
+                ecKey,
+                walletUnitAttestationCredential?.credentialIssuer
+            )
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching integrity token: ${e.message}")
+            null
+        }
+    }
+
+    private suspend fun prepareIntegrityTokenProvider(
+        context: Context,
+        cloudProjectNumber: Long
+    ): StandardIntegrityManager.StandardIntegrityTokenProvider =
+        suspendCancellableCoroutine { cont ->
+            val integrityManager = IntegrityManagerFactory.createStandard(context)
+
+            val prepareRequest = StandardIntegrityManager.PrepareIntegrityTokenRequest.builder()
+                .setCloudProjectNumber(cloudProjectNumber)
+                .build()
+
+            integrityManager.prepareIntegrityToken(prepareRequest)
+                .addOnSuccessListener { provider ->
+                    if (cont.isActive) cont.resume(provider)
+                }
+                .addOnFailureListener { exception ->
+                    if (cont.isActive) cont.resumeWithException(exception)
+                }
+        }
+
+    private suspend fun requestIntegrityToken(
+        tokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider,
+        requestHash: String?
+    ): String = suspendCancellableCoroutine { cont ->
+        try {
+            val tokenRequest = StandardIntegrityManager.StandardIntegrityTokenRequest.builder()
+                .setRequestHash(requestHash)
+                .build()
+
+            tokenProvider.request(tokenRequest)
+                .addOnSuccessListener { response ->
+                    if (cont.isActive) cont.resume(response.token())
+                }
+                .addOnFailureListener { exception ->
+                    if (cont.isActive) cont.resumeWithException(exception)
+                }
+        } catch (e: Exception) {
+            if (cont.isActive) cont.resumeWithException(e)
+        }
+    }
+
+    private suspend fun processWalletUnitAttestationRequest(
+        baseUrl: String,
+        token: String?,
+        nonce: String?,
+        clientAssertionValue: String?,
+        profile: String? = null
+    ): CredentialOfferResponse? = withContext(Dispatchers.IO) {
+
+        val clientAssertion = ClientAssertion(
+            clientAssertion = clientAssertionValue,
+            clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            profile = profile
+        )
+
+        val result = SafeApiCall.safeApiCallResponse {
+            ApiManager.api.getService()?.sendWUARequest(
+                url = "$baseUrl/wallet-unit/request",
+                deviceIntegrityToken = token ?: "",
+                devicePlatform = "android",
+                nonce = nonce ?: "",
+                body = clientAssertion
+            )
+        }
+
+        result.onSuccess { response ->
+            if (response.isSuccessful) {
+                val credentialOfferResponse = response.body()
+                Log.d(TAG, "Request successful: $credentialOfferResponse")
+                return@withContext credentialOfferResponse
+            } else {
+                Log.e(TAG, "Request failed: ${response.errorBody()?.string()}")
+                return@withContext null
+            }
+        }.onFailure { e ->
+            Log.e(TAG, "Error sending request: ${e.message}")
+            return@withContext null
+        }
+
+        return@withContext null // fallback
+    }
+
+
+    fun generateClientAssertion(
+        ecKey: ECKey,
+        did: String?,
+        audience: String?
+    ): String {
+        try {
+
+            Log.d(TAG, "Client assertion did:$did")
+            val now = Date()
+            val expTime = Date(now.time + 3600 * 1000)
+
+            // Create JWT Header
+            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+                .keyID("$did#${did?.replace("did:key:", "")}")
+                .type(JOSEObjectType.JWT)
+                .build()
+            Log.d(TAG, "Client assertion header:$header")
+
+            // Create JWT Payload
+            val payload = JWTClaimsSet.Builder()
+                .audience(audience)
+                .claim("client_id", did)
+                .claim("cnf", mapOf("jwk" to ecKey.toPublicJWK().toJSONObject()))
+                .expirationTime(expTime)
+                .issueTime(now)
+                .issuer(did)
+                .subject(did)
+                .jwtID("urn:uuid:${UUID.randomUUID().toString()}")
+                .build()
+            Log.d(TAG, "Client assertion payload:$payload")
+
+            // Create the SignedJWT object
+            val signedJWT = SignedJWT(header, payload)
+
+            // Sign the JWT with the ECKey's private key
+            val signer = ECDSASigner(ecKey)
+            signedJWT.sign(signer)
+
+            // Return the serialized token
+            return signedJWT.serialize()
+        } catch (e: Exception) {
+            Log.d(TAG, "Client assertion error: ${e.message.toString()}")
+            println(e.message)
+            return ""
+        }
+
+    }
+
+    private suspend fun fetchNonceForDeviceIntegrityToken(url: String): String? = withContext(Dispatchers.IO) {
+
+        val result = SafeApiCall.safeApiCallResponse {
+            ApiManager.api.getService()?.fetchNonce(url = url)
+        }
+
+        result.onSuccess { response ->
+            if (response.isSuccessful) {
+                val responseBody = response.body()?.string()
+                responseBody?.let {
+                    val nonceResponse = Gson().fromJson(it, NonceResponse::class.java)
+                    Log.d(TAG, "Nonce fetched successfully: ${nonceResponse.nonce}")
+                    return@withContext nonceResponse.nonce
+                }
+            } else {
+                Log.e(TAG, "Failed to fetch nonce: ${response.errorBody()?.string()}")
+                return@withContext null
+            }
+        }.onFailure { e ->
+            Log.e(TAG, "Error fetching nonce: ${e.localizedMessage}")
+            return@withContext null
+        }
+
+        return@withContext null // fallback
+    }
+
+
+    fun generateWUAProofOfPossession(
+        ecKey: ECKey,
+        did: String?,
+        aud: String?
+    ): String? {
+        try {
+            val now = Date()
+            val expirationTime = Date(now.time + 6 * 60 * 1000)
+
+            // Create the JWT claims
+            val claimsSet = JWTClaimsSet.Builder()
+                .issuer(did)
+                .audience(aud)
+                .issueTime(now)
+                .notBeforeTime(now)
+                .expirationTime(expirationTime)
+                .jwtID("urn:uuid:${UUID.randomUUID().toString()}")
+                .build()
+
+            // Create the JWS header
+            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(JOSEObjectType("oauth-client-attestation-pop+jwt"))
+                .build()
+
+            // Sign the JWT
+            val signedJWT = SignedJWT(header, claimsSet)
+
+            // Create signer with the private key
+            val signer = ECDSASigner(ecKey)
+
+            // Sign the JWT
+            signedJWT.sign(signer)
+
+            // Return the serialized JWT
+            return signedJWT.serialize()
+        } catch (e: Exception) {
+            Log.d("Error", e.message.toString())
+            return null
+        }
+
+    }
+
+    private fun generateES256Key(): KeyPair? {
+
+        val keyPairGenerator = KeyPairGenerator.getInstance("EC")
+
+        keyPairGenerator.initialize(256)
+
+        val keyPair: KeyPair = keyPairGenerator.generateKeyPair()
+
+        return keyPair
+    }
+
+}

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationUtil.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationUtil.kt
@@ -2,359 +2,59 @@ package com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation
 
 
 import android.content.Context
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
-import android.util.Log
-import com.ewc.eudi_wallet_oidc_android.CredentialOfferResponse
-import com.ewc.eudi_wallet_oidc_android.NonceResponse
 import com.ewc.eudi_wallet_oidc_android.WalletAttestationResult
-import com.ewc.eudi_wallet_oidc_android.models.ClientAssertion
-import com.ewc.eudi_wallet_oidc_android.services.did.DIDService
-import com.ewc.eudi_wallet_oidc_android.services.network.ApiManager
-import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall
-import com.ewc.eudi_wallet_oidc_android.services.nonceRequest.NonceService
-import com.ewc.eudi_wallet_oidc_android.services.sdjwt.SDJWTService
-import com.ewc.eudi_wallet_oidc_android.services.utils.generateHash
-import com.google.android.play.core.integrity.IntegrityManagerFactory
-import com.google.android.play.core.integrity.StandardIntegrityManager
-import com.google.gson.Gson
-import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSHeader
-import com.nimbusds.jose.JWSObject
-import com.nimbusds.jose.JWSSigner
-import com.nimbusds.jose.Payload
-import com.nimbusds.jose.crypto.ECDSASigner
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
-import com.nimbusds.jose.jwk.JWK
-import com.nimbusds.jwt.JWTClaimsSet
-import com.nimbusds.jwt.SignedJWT
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
-import java.nio.charset.StandardCharsets
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
-import java.security.PrivateKey
-import java.security.PublicKey
-import java.security.SecureRandom
-import java.security.interfaces.ECPrivateKey
-import java.security.interfaces.ECPublicKey
-import java.security.spec.ECGenParameterSpec
-import java.util.Base64
-import java.util.Date
-import java.util.UUID
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
-
+/**
+ * Deprecated facade kept for published-API compatibility.
+ * All WUA logic now lives in [WalletUnitAttestationService] and [WalletUnitAttestationHeaders].
+ */
+@Deprecated("WUA logic moved to WalletUnitAttestationService")
 object WalletAttestationUtil {
-    val TAG = "WalletUnitAttestation"
+    val TAG = WalletUnitAttestationService.TAG
+
+    // Legacy behavior: generateClientAssertion(ecKey, did) uses the baseUrl of the
+    // last initiateWalletUnitAttestation call as the audience claim.
     private var baseUrl: String? = null
 
 
+    @Deprecated(
+        "Use WalletUnitAttestationService.initiateWalletUnitAttestation",
+        ReplaceWith("WalletUnitAttestationService.initiateWalletUnitAttestation(context, cloudProjectNumber, baseUrl, inputEcKey)")
+    )
     suspend fun initiateWalletUnitAttestation(
         context: Context,
         cloudProjectNumber: Long,
         baseUrl: String,
-        inputEcKey:ECKey?
+        inputEcKey: ECKey?
     ): WalletAttestationResult? {
         this.baseUrl = baseUrl
-        var clientAssertion: String? = null
-        return try {
-            // Step 1: Generate the key pair with attestation
-            val ecKey = inputEcKey ?: run {
-                val keyPair = generateES256Key()
-                val publicKey = keyPair?.public?.let { DIDService().convertToECPublicKey(it) }
-                val privateKey = keyPair?.private?.let { DIDService().convertToECPrivateKey(it) }
-                Log.d(TAG, "Generated privateKey with attestation: $privateKey")
-                Log.d(TAG, "Generated publicKey with attestation: $publicKey")
-
-                ECKey.Builder(Curve.P_256, publicKey).privateKey(privateKey).build()
-            }
-            val did = DIDService().createDID(ecKey)
-            Log.d(TAG, "Generated DID: $did")
-            // Step 2: Prepare the integrity token provider
-            val tokenProvider = prepareIntegrityTokenProvider(context, cloudProjectNumber)
-            Log.d(TAG, "Prepare tokenProvider: $tokenProvider")
-
-            // Step 3: Fetch the nonce from the server
-            val nonce = fetchNonceForDeviceIntegrityToken("$baseUrl/nonce")
-            Log.d(TAG, "Fetched nonce: $nonce")
-
-            // Step 4: Generate a request hash from the nonce
-
-            val requestHash = nonce?.let { generateHash(it) }
-            Log.d(TAG, "Generated request hash: $requestHash")
-
-            // Step 5: Request an integrity token
-            val token = requestIntegrityToken(tokenProvider, requestHash)
-            Log.d(TAG, "integrity token:$token ")
-
-            // Step 6: Generate client assertion
-            clientAssertion = generateClientAssertion(ecKey,did)
-            Log.d(TAG, "clientAssertion:$clientAssertion ")
-
-
-            // Step 7: Process the wallet unit attestation request
-            val walletUnitAttestationCredential =
-                processWalletUnitAttestationRequest(token, nonce, clientAssertion)
-
-
-            // Step 8: Log and return both values
-            if (walletUnitAttestationCredential != null) {
-                Log.d("WalletUnitAttestationCredential", walletUnitAttestationCredential.toString())
-            }
-
-            WalletAttestationResult(
-                walletUnitAttestationCredential?.credentialOffer,
-                walletUnitAttestationCredential?.walletUnitAttestation,
-                clientAssertion,
-                did,
-                ecKey,
-                walletUnitAttestationCredential?.credentialIssuer
-            )
-
-        } catch (e: Exception) {
-            Log.e(TAG, "Error fetching integrity token: ${e.message}")
-            null
-        }
-    }
-
-    private suspend fun prepareIntegrityTokenProvider(
-        context: Context,
-        cloudProjectNumber: Long
-    ): StandardIntegrityManager.StandardIntegrityTokenProvider =
-        suspendCancellableCoroutine { cont ->
-            val integrityManager = IntegrityManagerFactory.createStandard(context)
-
-            val prepareRequest = StandardIntegrityManager.PrepareIntegrityTokenRequest.builder()
-                .setCloudProjectNumber(cloudProjectNumber)
-                .build()
-
-            integrityManager.prepareIntegrityToken(prepareRequest)
-                .addOnSuccessListener { provider ->
-                    if (cont.isActive) cont.resume(provider)
-                }
-                .addOnFailureListener { exception ->
-                    if (cont.isActive) cont.resumeWithException(exception)
-                }
-        }
-
-    private suspend fun requestIntegrityToken(
-        tokenProvider: StandardIntegrityManager.StandardIntegrityTokenProvider,
-        requestHash: String?
-    ): String = suspendCancellableCoroutine { cont ->
-        try {
-            val tokenRequest = StandardIntegrityManager.StandardIntegrityTokenRequest.builder()
-                .setRequestHash(requestHash)
-                .build()
-
-            tokenProvider.request(tokenRequest)
-                .addOnSuccessListener { response ->
-                    if (cont.isActive) cont.resume(response.token())
-                }
-                .addOnFailureListener { exception ->
-                    if (cont.isActive) cont.resumeWithException(exception)
-                }
-        } catch (e: Exception) {
-            if (cont.isActive) cont.resumeWithException(e)
-        }
-    }
-
-    private suspend fun processWalletUnitAttestationRequest(
-        token: String?,
-        nonce: String?,
-        clientAssertionValue: String?
-    ): CredentialOfferResponse? = withContext(Dispatchers.IO) {
-
-        val clientAssertion = ClientAssertion(
-            clientAssertion = clientAssertionValue,
-            clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        return WalletUnitAttestationService.initiateWalletUnitAttestation(
+            context, cloudProjectNumber, baseUrl, inputEcKey
         )
-
-        val result = SafeApiCall.safeApiCallResponse {
-            ApiManager.api.getService()?.sendWUARequest(
-                url = "$baseUrl/wallet-unit/request",
-                deviceIntegrityToken = token ?: "",
-                devicePlatform = "android",
-                nonce = nonce ?: "",
-                body = clientAssertion
-            )
-        }
-
-        result.onSuccess { response ->
-            if (response.isSuccessful) {
-                val credentialOfferResponse = response.body()
-                Log.d(TAG, "Request successful: $credentialOfferResponse")
-                return@withContext credentialOfferResponse
-            } else {
-                Log.e(TAG, "Request failed: ${response.errorBody()?.string()}")
-                return@withContext null
-            }
-        }.onFailure { e ->
-            Log.e(TAG, "Error sending request: ${e.message}")
-            return@withContext null
-        }
-
-        return@withContext null // fallback
     }
 
-
-
-     fun generateClientAssertion(
+    @Deprecated(
+        "Use WalletUnitAttestationService.generateClientAssertion with an explicit audience",
+        ReplaceWith("WalletUnitAttestationService.generateClientAssertion(ecKey, did, audience)")
+    )
+    fun generateClientAssertion(
         ecKey: ECKey,
         did: String?
     ): String {
-        try {
-
-            Log.d(TAG, "Client assertion did:$did")
-            val now = Date()
-            val expTime = Date(now.time + 3600 * 1000)
-
-            // Create JWT Header
-            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
-                .keyID("$did#${did?.replace("did:key:", "")}")
-                .type(JOSEObjectType.JWT)
-                .build()
-            Log.d(TAG, "Client assertion header:$header")
-
-            // Create JWT Payload
-            val payload = JWTClaimsSet.Builder()
-                .audience(baseUrl)
-                .claim("client_id", did)
-                .claim("cnf", mapOf("jwk" to ecKey.toPublicJWK().toJSONObject()))
-                .expirationTime(expTime)
-                .issueTime(now)
-                .issuer(did)
-                .subject(did)
-                .jwtID("urn:uuid:${UUID.randomUUID().toString()}")
-                .build()
-            Log.d(TAG, "Client assertion payload:$payload")
-
-            // Create the SignedJWT object
-            val signedJWT = SignedJWT(header, payload)
-
-            // Sign the JWT with the ECKey's private key
-            val signer = ECDSASigner(ecKey)
-            signedJWT.sign(signer)
-
-            // Return the serialized token
-            return signedJWT.serialize()
-        } catch (e: Exception) {
-            Log.d(TAG, "Client assertion error: ${e.message.toString()}")
-            println(e.message)
-            return ""
-        }
-
+        return WalletUnitAttestationService.generateClientAssertion(ecKey, did, audience = baseUrl)
     }
 
-    private fun getJWKFromKeystore(publicKey: PublicKey): JWK {
-        // Generate a unique Key ID (kid) based on the public key
-        val keyId = generateKeyId(publicKey)
-
-        // Create an EC JWK from the public key
-        val ecJWK = ECKey.Builder(Curve.P_256, publicKey as ECPublicKey?)
-            .keyID(keyId)
-            .build()
-
-        return ecJWK
-    }
-
-    private fun generateKeyId(publicKey: PublicKey): String {
-        val keyBytes = publicKey.encoded
-        val digest = MessageDigest.getInstance("SHA-256")
-        val hash = digest.digest(keyBytes)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash)
-    }
-
-    private suspend fun fetchNonceForDeviceIntegrityToken(url: String): String? = withContext(Dispatchers.IO) {
-
-        val result = SafeApiCall.safeApiCallResponse {
-            ApiManager.api.getService()?.fetchNonce(url = url)
-        }
-
-        result.onSuccess { response ->
-            if (response.isSuccessful) {
-                val responseBody = response.body()?.string()
-                responseBody?.let {
-                    val nonceResponse = Gson().fromJson(it, NonceResponse::class.java)
-                    Log.d(TAG, "Nonce fetched successfully: ${nonceResponse.nonce}")
-                    return@withContext nonceResponse.nonce
-                }
-            } else {
-                Log.e(TAG, "Failed to fetch nonce: ${response.errorBody()?.string()}")
-                return@withContext null
-            }
-        }.onFailure { e ->
-            Log.e(TAG, "Error fetching nonce: ${e.localizedMessage}")
-            return@withContext null
-        }
-
-        return@withContext null // fallback
-    }
-
-
-
+    @Deprecated(
+        "Use WalletUnitAttestationService.generateWUAProofOfPossession",
+        ReplaceWith("WalletUnitAttestationService.generateWUAProofOfPossession(ecKey, did, aud)")
+    )
     fun generateWUAProofOfPossession(
         ecKey: ECKey,
         did: String?,
         aud: String?
     ): String? {
-        try {
-            val now = Date()
-            val expirationTime = Date(now.time + 6 * 60 * 1000)
-
-            // Create the JWT claims
-            val claimsSet = JWTClaimsSet.Builder()
-                .issuer(did)
-                .audience(aud)
-                .issueTime(now)
-                .notBeforeTime(now)
-                .expirationTime(expirationTime)
-                .jwtID("urn:uuid:${UUID.randomUUID().toString()}")
-                .build()
-
-            // Create the JWS header
-            val header = JWSHeader.Builder(JWSAlgorithm.ES256)
-                .type(JOSEObjectType("oauth-client-attestation-pop+jwt"))
-                .build()
-
-            // Sign the JWT
-            val signedJWT = SignedJWT(header, claimsSet)
-
-            // Create signer with the private key
-            val signer = ECDSASigner(ecKey)
-
-            // Sign the JWT
-            signedJWT.sign(signer)
-
-            // Return the serialized JWT
-            return signedJWT.serialize()
-        }catch (e:Exception){
-            Log.d("Error",e.message.toString())
-            return null
-        }
-
-    }
-
-    private fun generateES256Key(): KeyPair? {
-
-        val keyPairGenerator = KeyPairGenerator.getInstance("EC")
-
-        keyPairGenerator.initialize(256)
-
-        val keyPair: KeyPair = keyPairGenerator.generateKeyPair()
-
-        return keyPair
+        return WalletUnitAttestationService.generateWUAProofOfPossession(ecKey, did, aud)
     }
 
 }
-
-
-

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/VerificationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/VerificationService.kt
@@ -10,6 +10,7 @@ import com.ewc.eudi_wallet_oidc_android.models.VPTokenResponse
 import com.ewc.eudi_wallet_oidc_android.models.WrappedPresentationRequest
 import com.ewc.eudi_wallet_oidc_android.models.WrappedVpTokenResponse
 import com.ewc.eudi_wallet_oidc_android.services.UrlUtils
+import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.WalletUnitAttestationHeaders
 import com.ewc.eudi_wallet_oidc_android.services.network.ApiManager
 import com.ewc.eudi_wallet_oidc_android.services.network.SafeApiCall.safeApiCallResponse
 import com.ewc.eudi_wallet_oidc_android.services.utils.JwtUtils.isValidJWT
@@ -91,14 +92,10 @@ class VerificationService : VerificationServiceInterface {
             )
         }
 
-        val headers = mutableMapOf<String, String>().apply {
-            if (!walletUnitAttestationJWT.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation"] = walletUnitAttestationJWT.removeSuffix("~")
-            }
-            if (!walletUnitProofOfPossession.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation-PoP"] = walletUnitProofOfPossession
-            }
-        }
+        val headers = WalletUnitAttestationHeaders.build(
+            walletUnitAttestationJWT,
+            walletUnitProofOfPossession
+        )
 
         return try {
             val params = AuthorisationResponseHandler().prepareAuthorisationResponse(
@@ -246,14 +243,10 @@ class VerificationService : VerificationServiceInterface {
             )
         }
 
-        val headers = mutableMapOf<String, String>().apply {
-            if (!walletUnitAttestationJWT.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation"] = walletUnitAttestationJWT.removeSuffix("~")
-            }
-            if (!walletUnitProofOfPossession.isNullOrEmpty()) {
-                this["OAuth-Client-Attestation-PoP"] = walletUnitProofOfPossession
-            }
-        }
+        val headers = WalletUnitAttestationHeaders.build(
+            walletUnitAttestationJWT,
+            walletUnitProofOfPossession
+        )
 
         return try {
             val params = AuthorisationResponseHandler().prepareAuthorisationResponseV2(

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/VerificationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/VerificationService.kt
@@ -89,6 +89,34 @@ class VerificationService : VerificationServiceInterface {
                 Log.d("BankIdWatch", "DCQL query[$i]=$chunk")
             }
         }
+        // Transaction data (TS12): each entry is base64url-encoded JSON.
+        val txData = pr?.transactionDdata
+        if (txData.isNullOrEmpty()) {
+            Log.d("TxWatch", "transaction_data: NONE")
+        } else {
+            Log.d("TxWatch", "transaction_data: ${txData.size} entries")
+            txData.forEachIndexed { i, entry ->
+                entry.chunked(3000).forEachIndexed { j, chunk ->
+                    Log.d("TxWatch", "transaction_data[$i] raw[$j]=$chunk")
+                }
+                try {
+                    val decoded = String(
+                        android.util.Base64.decode(
+                            entry,
+                            android.util.Base64.URL_SAFE or
+                                android.util.Base64.NO_WRAP or
+                                android.util.Base64.NO_PADDING
+                        ),
+                        Charsets.UTF_8
+                    )
+                    decoded.chunked(3000).forEachIndexed { j, chunk ->
+                        Log.d("TxWatch", "transaction_data[$i] json[$j]=$chunk")
+                    }
+                } catch (e: Exception) {
+                    Log.e("TxWatch", "transaction_data[$i] decode failed: ${e.message}")
+                }
+            }
+        }
     }
 
     override suspend fun processAndSendAuthorisationResponse(

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/VerificationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/VerificationService.kt
@@ -54,14 +54,19 @@ class VerificationService : VerificationServiceInterface {
         val request = uri.getQueryParameter("request")
         if (presentationDefinition != null || presentationDefinitionUri != null || dcqlQuery != null) {
             return AuthorisationRequestByValue().processAuthorisationRequest(data)
+                .also { logDcql("by_value", it) }
         } else if (!requestUri.isNullOrBlank()) {
             return AuthorisationRequestByReferenceWithRequestUri().processAuthorisationRequest(data)
+                .also { logDcql("request_uri", it) }
         } else if (request != null) {
             return AuthorisationRequestByReferenceWithRequest().processAuthorisationRequest(data)
+                .also { logDcql("request", it) }
         } else if (isValidJWT(data)) {
             return AuthorisationRequestByJWT().processAuthorisationRequest(data)
+                .also { logDcql("jwt", it) }
         } else if (iarOpenid4VPRequest != null){
             return AuthorisationRequestForIAR().processAuthorisationRequest(data)
+                .also { logDcql("iar", it) }
         } else {
             return WrappedPresentationRequest(
                 presentationRequest = null,
@@ -70,6 +75,19 @@ class VerificationService : VerificationServiceInterface {
                     errorDescription = "Invalid Request"
                 )
             )
+        }
+    }
+
+    private fun logDcql(source: String, wrapped: WrappedPresentationRequest?) {
+        val pr = wrapped?.presentationRequest
+        Log.d("BankIdWatch", "DCQL source=$source clientId=${pr?.clientId} responseMode=${pr?.responseMode} nonce=${pr?.nonce} error=${wrapped?.errorResponse?.errorDescription}")
+        val dcql = pr?.dcqlQuery
+        if (dcql == null) {
+            Log.d("BankIdWatch", "DCQL query: NONE (presentationDefinition=${pr?.presentationDefinition != null})")
+        } else {
+            Gson().toJson(dcql).chunked(3000).forEachIndexed { i, chunk ->
+                Log.d("BankIdWatch", "DCQL query[$i]=$chunk")
+            }
         }
     }
 
@@ -160,6 +178,7 @@ class VerificationService : VerificationServiceInterface {
 
                         response.code() == 302 || response.code() == 200 -> {
                             val locationHeader = response.headers()["Location"]
+                            Log.d("BankIdWatch", "direct_post response code=${response.code()} Location=$locationHeader Set-Cookie=${response.headers().values("Set-Cookie")}")
                             if (locationHeader?.contains("error=") == true) {
                                 val errorParams = locationHeader.substringAfter("?").split("&").associate {
                                     val (key, value) = it.split("=")
@@ -312,6 +331,7 @@ class VerificationService : VerificationServiceInterface {
 
                         response.code() == 302 || response.code() == 200 -> {
                             val locationHeader = response.headers()["Location"]
+                            Log.d("BankIdWatch", "direct_post response code=${response.code()} Location=$locationHeader Set-Cookie=${response.headers().values("Set-Cookie")}")
                             if (locationHeader?.contains("error=") == true) {
                                 val errorParams = locationHeader.substringAfter("?").split("&").associate {
                                     val (key, value) = it.split("=")

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/authorisationResponse/AuthorisationResponseBuilder.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/authorisationResponse/AuthorisationResponseBuilder.kt
@@ -9,7 +9,6 @@ import com.ewc.eudi_wallet_oidc_android.models.PathNested
 import com.ewc.eudi_wallet_oidc_android.models.PresentationDefinition
 import com.ewc.eudi_wallet_oidc_android.models.PresentationRequest
 import com.ewc.eudi_wallet_oidc_android.models.PresentationSubmission
-import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.WalletAttestationUtil
 import com.ewc.eudi_wallet_oidc_android.services.verification.PresentationDefinitionProcessor.processPresentationDefinition
 import com.ewc.eudi_wallet_oidc_android.services.verification.VerificationService
 import com.ewc.eudi_wallet_oidc_android.services.verification.idToken.IdTokenGenerator

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/authorisationResponse/VerifierJwk.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/authorisationResponse/VerifierJwk.kt
@@ -34,18 +34,27 @@ object VerifierJwk {
             Log.d(TAG, "Extracting key from embedded JWKS...")
             val jwksJson = clientMetadataJson.getAsJsonObject("jwks")
             val keysArray = jwksJson.getAsJsonArray("keys")
-            val matchedKey = keysArray.find {
-                it.asJsonObject.get("crv").asString == "P-256"
-            }?.asJsonObject
+            val p256Keys = keysArray
+                .map { it.asJsonObject }
+                .filter { k -> k.get("crv")?.takeIf { !it.isJsonNull }?.asString == "P-256" }
+            // The response is ENCRYPTED to this key, so the encryption key must
+            // be chosen: 'use: enc' first, then a key that declares no use.
+            // A 'sig' key is never acceptable — verifiers (e.g. BankID) publish
+            // both in one set, and the first P-256 key may be the signing key.
+            val matchedKey = p256Keys.firstOrNull { k ->
+                k.get("use")?.takeIf { !it.isJsonNull }?.asString == "enc"
+            } ?: p256Keys.firstOrNull { k ->
+                k.get("use") == null || k.get("use").isJsonNull
+            }
 
             if (matchedKey == null) {
-                Log.e(TAG, "No P-256 curve key found in client metadata.")
+                Log.e(TAG, "No P-256 encryption key (use=enc) found in client metadata.")
             } else {
-                Log.d(TAG, "Found P-256 key: $matchedKey")
+                Log.d(TAG, "Found P-256 encryption key: $matchedKey")
             }
 
             matchedKey
-                ?: throw IllegalArgumentException("No P-256 curve key found in client metadata")
+                ?: throw IllegalArgumentException("No P-256 encryption key found in client metadata")
         }
 
         val publicECJWK = ECKey.Builder(

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/filterCredentials/DCQLCredentialFilter.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/filterCredentials/DCQLCredentialFilter.kt
@@ -15,7 +15,10 @@ class DCQLCredentialFilter {
     ): List<List<String>> {
         val response: MutableList<MutableList<String>> = mutableListOf()
 
+        android.util.Log.d("BankIdWatch", "DCQL filter: queries=${dcqlQuery?.credentials?.size} walletCredentials=${allCredentialList.size} credentialSets=${dcqlQuery?.credential_sets?.size}")
+
         dcqlQuery?.credentials?.forEach { dcqlCredential ->
+            android.util.Log.d("BankIdWatch", "DCQL filter query id=${dcqlCredential.id} format=${dcqlCredential.format} meta=${com.google.gson.Gson().toJson(dcqlCredential.meta)} claims=${com.google.gson.Gson().toJson(dcqlCredential.claims)}")
             var processedCredentials: MutableList<String> = mutableListOf()
             var credentialList: ArrayList<String?> = arrayListOf()
             var credentialFormat: String? = null
@@ -67,6 +70,7 @@ class DCQLCredentialFilter {
             response.add(finalFilteredList.toMutableList())
         }
 
+        android.util.Log.d("BankIdWatch", "DCQL filter result: matchesPerQuery=${response.map { it.size }}")
         return response
     }
 }

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/vpTokenBuilders/SDJWTVpTokenBuilder.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/verification/vpTokenBuilders/SDJWTVpTokenBuilder.kt
@@ -7,7 +7,6 @@ import com.ewc.eudi_wallet_oidc_android.models.InputDescriptors
 import com.ewc.eudi_wallet_oidc_android.models.PresentationRequest
 import com.ewc.eudi_wallet_oidc_android.services.utils.createKeyBindingJWT
 import com.ewc.eudi_wallet_oidc_android.services.utils.generateHash
-import com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation.WalletAttestationUtil
 import com.ewc.eudi_wallet_oidc_android.services.verification.VerificationService
 import com.nimbusds.jose.jwk.JWK
 import org.json.JSONObject


### PR DESCRIPTION
Body
Adds ARF TS3 v1.5 wallet unit attestation and key attestation support, and fixes the
OpenID4VCI 1.0 / OpenID4VP paths that strict third-party issuers and verifiers reject
(verified against Czech BankID and iGrant.io staging).

### Wallet unit attestation (TS3 v1.5)
- `WalletUnitAttestationService` — the WUA registration flow moves out of
  `WalletAttestationUtil` (kept as a deprecated facade), with an explicit audience and an
  optional `ts3` profile in the client assertion.
- `WalletUnitAttestationHeaders` — one place for the `OAuth-Client-Attestation` /
  `OAuth-Client-Attestation-PoP` header pair and the `client_id` (`sub`) extraction.
- `StatusClaims` — revocation status lookup also reads the TS3 WIA `client_status`
  location.

### Key attestation
- `KeyAttestationService` produces TS3 key attestations for credential-request proofs:
  a software tier (binding key) and a hardware tier (Android Keystore key with a
  Google-rooted chain in `x5c`), both bound to the proof `c_nonce`, plus the
  wallet-provider key-attestation and nonce endpoints.
- Per TS3 2.2.2.1 the KA SHALL be generated and signed by the Wallet Provider, so
  `forProof()` only passes a wallet-provider-issued KA through to the proof header —
  the on-device mint functions and the wallet-provider nonce fetch used for them are
  removed. The nonce sent with the KA request is the **issuer's** `c_nonce` (TS3 2.2.2);
  the issuer validates its freshness.
- `ProofService` carries the attestation in the `key_attestation` JOSE header of the jwt
  proof; `IssueService` and `ReIssuanceService` plumb `attachKeyAttestation` and a
  pre-fetched KA through `processCredentialRequest`, so re-issuance can attach one too.

### OpenID4VCI 1.0
- The nonce request is no longer authenticated. 1.0 defines the nonce endpoint as
  unauthenticated; sending `Authorization: Bearer <token>` (a Bearer copy of a DPoP-bound
  token) made strict issuers answer 401 with an empty body, and the lost `c_nonce`
  disabled the hardware key-attestation tier and sent the proof without a nonce.
- `credential_configuration_id` is sent whenever the issuer metadata publishes a nonce
  endpoint. The branch was additionally gated on the token response *not* carrying a
  `c_nonce`; issuers that do both fell through to the legacy `format` + `vct` body, which
  a strict 1.0 credential endpoint rejects as an invalid request format.
- `processDeferredCredentialRequestV2` takes the DPoP key used at the token endpoint, so
  a DPoP-bound access token reaches the deferred endpoint as `Authorization: DPoP <token>`
  with a fresh proof (`htm` POST, `htu` = deferred endpoint, `ath`, fresh `jti`), on both
  the plain and the encrypted V2 calls. Callers that pass no key keep Bearer.

### Response encryption
- With an embedded verifier JWKS, the encryption key is selected by declared use: prefer
  `use: enc`, accept a key with no `use`, never a `sig` key. Previously the first P-256
  key won, so verifiers publishing signing and encryption keys in one set received a
  response encrypted to their signing key and could not decrypt it. The `jwks_uri` branch
  already filtered this way.    