### PR TITLE
Fix #670 : Apply a configurable clock-skew allowance to the client attestation PoP

### DIFF
--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/clock/WalletClock.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/clock/WalletClock.kt
@@ -1,0 +1,59 @@
+package com.ewc.eudi_wallet_oidc_android.clock
+
+import java.util.Date
+
+/**
+ * The single time source for every JWT this SDK mints.
+ *
+ * Wallets sign short-lived tokens — DPoP proofs, client-attestation PoPs, key-attestation PoPs,
+ * credential proofs, KB-JWTs, VP tokens — whose `iat`/`nbf` are checked by a remote server against
+ * *its* clock. Two machines never agree exactly, and a server with little or no forward tolerance
+ * rejects anything it sees in its own future. BankID's authorization server does this: a PoP one
+ * second old is refused with `INVALID_ISSUED_AT` (confirmed on device, 2026-08-20 — backdating
+ * fixes it, removing the backdate reproduces the failure).
+ *
+ * So `iat` and `nbf` are stamped [skewBackdateMillis] in the past, while `exp` is measured from the
+ * real [now] — the token's usable lifetime is unchanged, it is only declared to have started
+ * slightly earlier.
+ *
+ * ```kotlin
+ * // Application.onCreate, or a developer-settings screen
+ * WalletClock.configure(skewBackdateMillis = 60_000)   // default
+ * WalletClock.configure(skewBackdateMillis = 0)        // stamp exact device time
+ * ```
+ *
+ * **This is a mitigation, not a cure.** It compensates only for the device running *ahead* of the
+ * server; a device running behind is unaffected, and drift larger than the allowance starts failing
+ * again. It also spends from any maximum-age budget the server enforces on `iat`, so keep it well
+ * under the shortest token lifetime here (the client-attestation PoP, 6 minutes). The durable fix is
+ * for the wallet to learn the server's own clock from its `Date` response header, and for servers to
+ * apply the leeway RFC 7519 §4.1.4 expects of them.
+ */
+object WalletClock {
+
+    /** Backdate applied to `iat`/`nbf`. 60 s absorbs ordinary drift without risking a max-age check. */
+    const val DEFAULT_SKEW_BACKDATE_MILLIS = 60 * 1000L
+
+    @Volatile
+    var skewBackdateMillis: Long = DEFAULT_SKEW_BACKDATE_MILLIS
+        private set
+
+    /**
+     * Sets the skew allowance. Call once at startup, or from a developer-settings screen.
+     *
+     * @param skewBackdateMillis how far into the past to stamp `iat`/`nbf`. Negative values are
+     *   clamped to zero — post-dating a token would put it in *every* server's future.
+     */
+    @JvmStatic
+    fun configure(skewBackdateMillis: Long) {
+        this.skewBackdateMillis = skewBackdateMillis.coerceAtLeast(0L)
+    }
+
+    /** Real device time. Use for `exp`, so the allowance never shortens a token's life. */
+    @JvmStatic
+    fun now(): Date = Date()
+
+    /** Device time minus the skew allowance. Use for `iat` and `nbf`. */
+    @JvmStatic
+    fun issuedAt(): Date = Date(System.currentTimeMillis() - skewBackdateMillis)
+}

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
@@ -370,6 +370,15 @@ class IssueService : IssueServiceInterface {
                             urlBuilder.appendQueryParameter("request_uri", requestUri)
                             return urlBuilder.build().toString()
                         }
+                    } else {
+                        // A rejected PAR used to be swallowed silently. The Date header is the
+                        // server's own clock — compare it with the PoP iat logged above.
+                        Log.e(
+                            "BankIdWatch",
+                            "PAR REJECTED code=${parResponse.code()} " +
+                                "serverDate=${parResponse.headers()["Date"]} " +
+                                "body=${parResponse.errorBody()?.string()}"
+                        )
                     }
                 },
                 onFailure = { error ->

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/walletUnitAttestation/WalletUnitAttestationService.kt
@@ -4,6 +4,7 @@ package com.ewc.eudi_wallet_oidc_android.services.utils.walletUnitAttestation
 import android.content.Context
 import android.util.Log
 import com.ewc.eudi_wallet_oidc_android.CredentialOfferResponse
+import com.ewc.eudi_wallet_oidc_android.clock.WalletClock
 import com.ewc.eudi_wallet_oidc_android.NonceResponse
 import com.ewc.eudi_wallet_oidc_android.WalletAttestationResult
 import com.ewc.eudi_wallet_oidc_android.models.ClientAssertion
@@ -273,15 +274,16 @@ object WalletUnitAttestationService {
         aud: String?
     ): String? {
         try {
-            val now = Date()
+            val now = WalletClock.now()
+            val issuedAt = WalletClock.issuedAt()
             val expirationTime = Date(now.time + 6 * 60 * 1000)
 
             // Create the JWT claims
             val claimsSet = JWTClaimsSet.Builder()
                 .issuer(did)
                 .audience(aud)
-                .issueTime(now)
-                .notBeforeTime(now)
+                .issueTime(issuedAt)
+                .notBeforeTime(issuedAt)
                 .expirationTime(expirationTime)
                 .jwtID("urn:uuid:${UUID.randomUUID().toString()}")
                 .build()


### PR DESCRIPTION
Issuance failed intermittently at the pushed authorization request, with BankID rejecting the OAuth-Client-Attestation-PoP header as INVALID_ISSUED_AT.

The PoP was not stale: it is minted immediately before the request and is about a second old on the wire. It carried the device's wall-clock time directly, so a device running ahead of the authorization server produced a token the server saw in its own future and refused. Confirmed on device by toggling the allowance: with it the request succeeds, without it the same request reproduces the rejection.

WalletClock is the single time source for minted tokens. issuedAt() stamps iat and nbf a configurable interval in the past, while now() supplies exp, so the allowance never shortens a token's usable life. The default is 60 seconds; hosts can change it, including to zero, through WalletClock.configure().

This compensates only for the device running ahead of the server, and drift larger than the allowance will fail again. It also spends from any maximum age a server enforces on iat, so the value is kept well under the PoP's own six-minute lifetime. Deriving the offset from the server's Date response header would correct both directions and is the better long-term fix; the remaining mint sites still stamp raw device time and are not addressed here.

A rejected PAR was also swallowed silently, because the response was only handled on the success path. Such a rejection now logs its status, the server's Date header and the error body, which is what made this diagnosable.