### PR TITLE
Backdate iat on DPoP and credential proofs (BankID INVALID_ISSUED_AT)

### DIFF
--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/issue/IssueService.kt
@@ -56,6 +56,7 @@ import okhttp3.ResponseBody
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.util.Base64
 import retrofit2.Response
 import java.util.Date
 import java.util.UUID
@@ -706,6 +707,25 @@ class IssueService : IssueServiceInterface {
             }
         }
 
+        // --- invalid_client_attestation diagnostics (filter: adb logcat -s KaWatch) ---
+        // The AS rejects the token request when the client attestation (WIA), its PoP, or
+        // the DPoP binding is wrong. Log the decoded, non-secret fields so a rejection can
+        // be traced to iss/aud/exp/nonce or a DPoP <-> WIA cnf key mismatch (the TS3 rule
+        // that the DPoP key must equal the WIA cnf key).
+        try {
+            val dpopThumb = dpopKey?.computeThumbprint()?.toString()
+            Log.d("KaWatch", "token request: endpoint=$tokenEndPoint clientId=$did grant=${if (isPreAuthorisedCodeFlow == true) "pre-authorized_code" else "authorization_code"} hasWIA=${walletUnitAttestationJWT != null} hasPoP=${walletUnitProofOfPossession != null} dpopKid=${dpopKey?.keyID} dpopThumb=$dpopThumb")
+            val wia = decodeJwtPayloadForLog(walletUnitAttestationJWT)
+            val wiaCnf = wia?.optJSONObject("cnf")?.optJSONObject("jwk")
+            Log.d("KaWatch", "token request WIA: iss=${wia?.opt("iss")} sub=${wia?.opt("sub")} aud=${wia?.opt("aud")} iat=${wia?.opt("iat")} exp=${wia?.opt("exp")} cnf.jwk=$wiaCnf")
+            val pop = decodeJwtPayloadForLog(walletUnitProofOfPossession)
+            Log.d("KaWatch", "token request WIA-PoP: iss=${pop?.opt("iss")} aud=${pop?.opt("aud")} iat=${pop?.opt("iat")} exp=${pop?.opt("exp")} jti=${pop?.opt("jti")} nonce=${pop?.opt("nonce")}")
+            val wiaCnfThumb = wiaCnf?.let { runCatching { ECKey.parse(it.toString()).computeThumbprint().toString() }.getOrNull() }
+            Log.d("KaWatch", "token request key-binding: dpopThumb=$dpopThumb wiaCnfThumb=$wiaCnfThumb match=${dpopThumb != null && dpopThumb == wiaCnfThumb}")
+        } catch (e: Exception) {
+            Log.e("KaWatch", "token request: attestation diagnostics failed: ${e.message}")
+        }
+
         val result = SafeApiCall.safeApiCallResponse {
             ApiManager.api.getService()?.getAccessTokenFromCode(
                 tokenEndPoint ?: "",
@@ -753,8 +773,10 @@ class IssueService : IssueServiceInterface {
 
                     (response.code() >= 400) -> {
                         try {
+                            val errorBodyString = response.errorBody()?.string()
+                            Log.e("KaWatch", "token endpoint ${response.code()} endpoint=$tokenEndPoint error=$errorBodyString")
                             WrappedTokenResponse(
-                                errorResponse = ErrorHandler.processError(response.errorBody()?.string())
+                                errorResponse = ErrorHandler.processError(errorBodyString)
                             )
                         } catch (e: Exception) {
                             null
@@ -765,12 +787,29 @@ class IssueService : IssueServiceInterface {
                 }
             },
             onFailure = { error ->
+                Log.e("KaWatch", "token request FAILED endpoint=$tokenEndPoint error=${error.message}")
                 println("Error while processing token request: ${error.message}")
                 WrappedTokenResponse(
                     errorResponse = ErrorHandler.processError(error.message)
                 )
             }
         )
+    }
+
+    /**
+     * Decodes a JWT / SD-JWT payload to JSON for diagnostic logging only (no signature
+     * check). Tolerates the SD-JWT trailing '~' and base64url without padding.
+     */
+    private fun decodeJwtPayloadForLog(jwt: String?): JSONObject? {
+        if (jwt.isNullOrBlank()) return null
+        return try {
+            val parts = jwt.substringBefore("~").split(".")
+            if (parts.size < 2) return null
+            JSONObject(String(Base64.getUrlDecoder().decode(parts[1])))
+        } catch (e: Exception) {
+            Log.e("KaWatch", "decodeJwtPayloadForLog failed: ${e.message}")
+            null
+        }
     }
 
 

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/DPoPProofService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/DPoPProofService.kt
@@ -3,11 +3,11 @@ package com.ewc.eudi_wallet_oidc_android.services.utils
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
+import com.ewc.eudi_wallet_oidc_android.clock.WalletClock
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
-import java.util.Date
 import java.util.UUID
 
 class DPoPProofService {
@@ -36,7 +36,9 @@ class DPoPProofService {
                 .jwtID(UUID.randomUUID().toString())
                 .claim("htm", httpMethod.uppercase())
                 .claim("htu", targetUri)
-                .issueTime(Date())
+                // Backdate iat so a server with zero forward tolerance (BankID's AS
+                // rejects a proof it sees in its own future) accepts the DPoP proof.
+                .issueTime(WalletClock.issuedAt())
 
             claims?.forEach { (key, value) ->
                 claimsBuilder.claim(key, value)

--- a/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/ProofService.kt
+++ b/eudi-wallet-oidc-android/src/main/java/com/ewc/eudi_wallet_oidc_android/services/utils/ProofService.kt
@@ -14,6 +14,7 @@ import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.OctetKeyPair
 import com.nimbusds.jose.util.Base64URL
+import com.ewc.eudi_wallet_oidc_android.clock.WalletClock
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import java.util.Date
@@ -47,8 +48,11 @@ class ProofService {
         // Add claims
         val claimsSet = JWTClaimsSet
             .Builder()
-            .issueTime(Date())
-            .expirationTime(Date(Date().time + 86400))
+            // Backdate iat so a server with zero forward tolerance (BankID's AS rejects a
+            // proof it sees in its own future) accepts the openid4vci credential proof;
+            // exp stays on real now so the usable lifetime is unchanged.
+            .issueTime(WalletClock.issuedAt())
+            .expirationTime(Date(WalletClock.now().time + 86400))
             .issuer(did)
             .audience(issuerConfig?.credentialIssuer ?: "")
             .claim("nonce", nonce).build()


### PR DESCRIPTION
## Why
BankID's authorization server enforces ~zero forward tolerance on the `iat` of client-attestation / DPoP / credential proofs: a proof it sees even a second in its own future is rejected with `INVALID_ISSUED_AT`. This happens even with an accurate, network-synced device clock, because the server clock + network latency can leave our `iat` in the server's future — so it's intermittent (issuance succeeded ~1 in 4 tries).

BankID confirmed: `[POST /oauth2/pushed-auth] Client attestation failed: INVALID_ISSUED_AT - PoP issued at is not valid`.

`WalletClock` already backdates the client-attestation PoP `iat`/`nbf` by 60s and fixes the PAR rejection. This PR extends the same mitigation to the two remaining short-lived proofs that hit the same servers.

## What
- **DPoPProofService** — `iat` now `WalletClock.issuedAt()` (was `Date()`).
- **ProofService** (OpenID4VCI credential proof) — `iat` now `WalletClock.issuedAt()`; `exp` measured from `WalletClock.now()`, so the usable lifetime is unchanged.
- **IssueService** — diagnostics on the token request (tag `KaWatch`): decoded WIA / PoP / DPoP fields, the DPoP↔WIA `cnf` key-binding check, and the raw AS error body. Logging only, no behaviour change.

## Notes
- `exp` stays on real now; only the declared start moves ~60s earlier.
- Still on raw `Date()` (follow-up if needed): the `client_assertion` builder (`WalletUnitAttestationService:219`) and `KeyAttestationService` key-PoP (goes to the lenient iGrant WP endpoint).
- Durable fix, per `WalletClock`'s own docstring, is to learn the server clock from its `Date` response header; this PR applies the existing 60s-backdate mitigation consistently.

## Test
- Composite build compiles (`:app:compileDebugKotlin` green).
- Retest BankID SUA IBAN issuance; `adb logcat -s KaWatch` shows the new diagnostics.