### PR TITLE
Fix #679 : Add missing copyright details to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2026] [iGrant Technologies AB (iGrant.io), Sweden]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
LICENSE still carried the unfilled Apache 2.0 boilerplate placeholder, so the SDK shipped without a named copyright owner.

Copyright [yyyy] [name of copyright owner]
-> Copyright [2026] [iGrant Technologies AB (iGrant.io), Sweden]